### PR TITLE
Add API Gateway S3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ publishes hourly lists of content to S3 for consumption by the
 The content in S3 is used to print daily versions of the newspaper where 
 internet connectivity may be limited.
 
+Further documentation is available in the [`/docs` folder](./docs/).
+
 ## Developing
 
 - `./scripts/setup` to get the project bootstrapped

--- a/docs/adr/01-architecture-pattern.md
+++ b/docs/adr/01-architecture-pattern.md
@@ -1,5 +1,7 @@
 # Architectural Pattern and Backend Language
 
+## Context
+
 This service is replacing an on-premise service that runs in a cron job, taking data about fronts and from the content API to produce json output in S3 
 which is consumed by [pressreader](https://about.pressreader.com/cruises-ferries/)
 

--- a/docs/adr/02-api-gateway.md
+++ b/docs/adr/02-api-gateway.md
@@ -1,6 +1,6 @@
 # Use of API Gateway to serve data
 
-## Context
+## Context
 
 [Pressreader](https://about.pressreader.com/cruises-ferries/) need to consume the data produced by this service, which is uploaded via a scheduled lambda into S3 with a predicatable name in the for `YYYYMMDD`.
 

--- a/docs/adr/02-api-gateway.md
+++ b/docs/adr/02-api-gateway.md
@@ -1,0 +1,7 @@
+# Use of API Gateway
+
+public bucket vs load balancer vs api gateway
+
+auth methods - might overcomplicate
+
+Replaces public buckets - not intended for auth, but to make safe for public consumption

--- a/docs/adr/02-api-gateway.md
+++ b/docs/adr/02-api-gateway.md
@@ -1,7 +1,41 @@
-# Use of API Gateway
+# Use of API Gateway to serve data
 
-public bucket vs load balancer vs api gateway
+## Context
 
-auth methods - might overcomplicate
+[Pressreader](https://about.pressreader.com/cruises-ferries/) need to consume the data produced by this service, which is uploaded via a scheduled lambda into S3 with a predicatable name in the for `YYYYMMDD`.
 
-Replaces public buckets - not intended for auth, but to make safe for public consumption
+Although the data produced does not contain any information we wish to keep private, we should avoid related incidental security risks and attacks that may increase costs.
+
+It is unlikely to be time/cost effective for the consumer to perform complex authentication.
+
+## Options
+
+### Serve data from a public S3 bucket
+
+This would work as a method for serving content. However when attempting to create public buckets AWS warns "We highly recommend that you never grant any kind of public access to your S3 bucket", and there are [many good reasons](https://serverfault.com/questions/888487/why-does-aws-recommend-against-public-s3-buckets) to avoid this.
+
+These include potential attacks that result in increased costs from uncontrolled downloads of objects, and the potential for unintended content to be made available.
+
+### EC2 Autoscaling Group / ALB
+
+We could serve this content from an EC2 instance, but this would add infrastructure for us to maintain, as well as a monthly fixed cost for the instance & ALB. 
+
+### CloudFront distribution / Private S3 bucket
+
+It is possible to create a CloudFront distribution that would point at a private S3 bucket, not requiring the maintenance of an EC2 instance. However CloudFront is not well user at the Guardian, and there are limited options for authentication and rate-limiting.
+
+### API Gateway with an S3 integration
+
+API Gateway can be configured to serve content from a private S3 bucket, with no lambda or other compute infrastructure needed. This method also offers rate-limiting to avoid potential high transfer costs and simple client identification via api keys in a `x-api-key` header. We may also define specific paths and file patterns that can be accessible.
+
+AWS [does not recommend that API Gateway API keys](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html#apigateway-usage-plans-best-practices) are used for authentication or authorization. However in this case our main concern is attacks that involve high costs from excessive downloads.
+
+### API Gateway to a Lambda proxying content from S3
+
+As with the previous option we have rate-limiting and API keys, but we also would need to maintain application code.
+
+## Decision
+
+We will implement API Gateway with S3 integration as it offers the most benefits (simple auth, rate limit), with the least infrastructure / application code to maintain.
+
+API Gateway with usage plans & API Keys seems to be an effective way to make data available at low volumes / request rates in a way that reduces risk for making this API endpoints available with authentication.

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -87,12 +87,20 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": "s3:Get",
+              "Action": "s3:GetObject",
               "Effect": "Allow",
               "Resource": {
-                "Fn::GetAtt": [
-                  "PressreaderDataBucketPressreader48E10950",
-                  "Arn",
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "PressreaderDataBucketPressreader48E10950",
+                        "Arn",
+                      ],
+                    },
+                    "/data/*",
+                  ],
                 ],
               },
             },
@@ -139,7 +147,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     "PressReaderAPI27D6A559": {
       "Properties": {
         "Description": "Serves data to Press Reader from an S3 bucket.",
-        "MinimumCompressionSize": 0,
         "Name": "Press Reader API",
         "Tags": [
           {
@@ -229,11 +236,10 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "PressReaderAPIDeployment7637267952cbe75bed63d0c64d74821a6c2a3b81": {
+    "PressReaderAPIDeployment76372679b73fc68b30f25fdf1147ce7be2abf5c5": {
       "DependsOn": [
-        "PressReaderAPIdatafolderkeyGET0804CE69",
-        "PressReaderAPIdatafolderkeyAE4BFC59",
-        "PressReaderAPIdatafolderD3E21776",
+        "PressReaderAPIdatakeyGET902D4076",
+        "PressReaderAPIdatakey9D39D3B4",
         "PressReaderAPIdata6C16C1E3",
       ],
       "Properties": {
@@ -250,7 +256,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment7637267952cbe75bed63d0c64d74821a6c2a3b81",
+          "Ref": "PressReaderAPIDeployment76372679b73fc68b30f25fdf1147ce7be2abf5c5",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -279,17 +285,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
     "PressReaderAPIPressReaderAPIUsagePlan5896C6C0": {
       "Properties": {
-        "ApiStages": [
-          {
-            "ApiId": {
-              "Ref": "PressReaderAPI27D6A559",
-            },
-            "Stage": {
-              "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
-            },
-            "Throttle": {},
-          },
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -309,7 +304,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "Throttle": {
-          "RateLimit": 5,
+          "RateLimit": 25,
         },
       },
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -375,22 +370,10 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "PressReaderAPIdatafolderD3E21776": {
+    "PressReaderAPIdatakey9D39D3B4": {
       "Properties": {
         "ParentId": {
           "Ref": "PressReaderAPIdata6C16C1E3",
-        },
-        "PathPart": "{folder}",
-        "RestApiId": {
-          "Ref": "PressReaderAPI27D6A559",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "PressReaderAPIdatafolderkeyAE4BFC59": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "PressReaderAPIdatafolderD3E21776",
         },
         "PathPart": "{key}",
         "RestApiId": {
@@ -399,7 +382,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "PressReaderAPIdatafolderkeyGET0804CE69": {
+    "PressReaderAPIdatakeyGET902D4076": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "GET",
@@ -420,7 +403,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
             },
           ],
           "RequestParameters": {
-            "integration.request.path.folder": "method.request.path.folder",
             "integration.request.path.key": "method.request.path.key",
           },
           "Type": "AWS",
@@ -440,7 +422,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 {
                   "Ref": "PressreaderDataBucketPressreader48E10950",
                 },
-                "/{key}",
+                "/data/{key}",
               ],
             ],
           },
@@ -448,6 +430,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "MethodResponses": [
           {
             "ResponseParameters": {
+              "method.response.header.Content-Length": true,
               "method.response.header.Content-Type": true,
             },
             "StatusCode": "200",
@@ -455,11 +438,10 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
         "RequestParameters": {
           "method.request.header.Content-Type": true,
-          "method.request.path.folder": true,
           "method.request.path.key": true,
         },
         "ResourceId": {
-          "Ref": "PressReaderAPIdatafolderkeyAE4BFC59",
+          "Ref": "PressReaderAPIdatakey9D39D3B4",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -774,7 +756,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                         "Arn",
                       ],
                     },
-                    "/*",
+                    "/data/*",
                   ],
                 ],
               },

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -229,10 +229,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "PressReaderAPIDeployment76372679e5f9cc7c2f05ed5f404ba8c9db4a6514": {
+    "PressReaderAPIDeployment7637267952cbe75bed63d0c64d74821a6c2a3b81": {
       "DependsOn": [
-        "PressReaderAPIdatakeyGET902D4076",
-        "PressReaderAPIdatakey9D39D3B4",
+        "PressReaderAPIdatafolderkeyGET0804CE69",
+        "PressReaderAPIdatafolderkeyAE4BFC59",
+        "PressReaderAPIdatafolderD3E21776",
         "PressReaderAPIdata6C16C1E3",
       ],
       "Properties": {
@@ -249,7 +250,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment76372679e5f9cc7c2f05ed5f404ba8c9db4a6514",
+          "Ref": "PressReaderAPIDeployment7637267952cbe75bed63d0c64d74821a6c2a3b81",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -278,6 +279,17 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
     "PressReaderAPIPressReaderAPIUsagePlan5896C6C0": {
       "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "PressReaderAPI27D6A559",
+            },
+            "Stage": {
+              "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
+            },
+            "Throttle": {},
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -363,10 +375,22 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "PressReaderAPIdatakey9D39D3B4": {
+    "PressReaderAPIdatafolderD3E21776": {
       "Properties": {
         "ParentId": {
           "Ref": "PressReaderAPIdata6C16C1E3",
+        },
+        "PathPart": "{folder}",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIdatafolderkeyAE4BFC59": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "PressReaderAPIdatafolderD3E21776",
         },
         "PathPart": "{key}",
         "RestApiId": {
@@ -375,7 +399,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::Resource",
     },
-    "PressReaderAPIdatakeyGET902D4076": {
+    "PressReaderAPIdatafolderkeyGET0804CE69": {
       "Properties": {
         "AuthorizationType": "NONE",
         "HttpMethod": "GET",
@@ -396,6 +420,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
             },
           ],
           "RequestParameters": {
+            "integration.request.path.folder": "method.request.path.folder",
             "integration.request.path.key": "method.request.path.key",
           },
           "Type": "AWS",
@@ -430,10 +455,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
         "RequestParameters": {
           "method.request.header.Content-Type": true,
+          "method.request.path.folder": true,
           "method.request.path.key": true,
         },
         "ResourceId": {
-          "Ref": "PressReaderAPIdatakey9D39D3B4",
+          "Ref": "PressReaderAPIdatafolderkeyAE4BFC59",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -236,7 +236,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "PressReaderAPIDeployment76372679b73fc68b30f25fdf1147ce7be2abf5c5": {
+    "PressReaderAPIDeployment76372679b767bd6c2d07c973927fa790b7ede477": {
       "DependsOn": [
         "PressReaderAPIdatakeyGET902D4076",
         "PressReaderAPIdatakey9D39D3B4",
@@ -256,7 +256,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment76372679b73fc68b30f25fdf1147ce7be2abf5c5",
+          "Ref": "PressReaderAPIDeployment76372679b767bd6c2d07c973927fa790b7ede477",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -285,6 +285,17 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
     "PressReaderAPIPressReaderAPIUsagePlan5896C6C0": {
       "Properties": {
+        "ApiStages": [
+          {
+            "ApiId": {
+              "Ref": "PressReaderAPI27D6A559",
+            },
+            "Stage": {
+              "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
+            },
+            "Throttle": {},
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -304,7 +315,8 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "Throttle": {
-          "RateLimit": 25,
+          "BurstLimit": 10,
+          "RateLimit": 10,
         },
       },
       "Type": "AWS::ApiGateway::UsagePlan",
@@ -384,6 +396,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
     "PressReaderAPIdatakeyGET902D4076": {
       "Properties": {
+        "ApiKeyRequired": true,
         "AuthorizationType": "NONE",
         "HttpMethod": "GET",
         "Integration": {

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -5,6 +5,8 @@ exports[`The PressReader stack matches the snapshot 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuS3Bucket",
+      "GuCertificate",
+      "GuCname",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
     ],
@@ -144,6 +146,41 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
+    "CertificatePressreader5EF99BC2": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "pressreader.gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Name",
+            "Value": "PressReader/CertificatePressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
     "PressReaderAPI27D6A559": {
       "Properties": {
         "Description": "Serves data to Press Reader from an S3 bucket.",
@@ -236,7 +273,53 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "PressReaderAPIDeployment76372679b767bd6c2d07c973927fa790b7ede477": {
+    "PressReaderAPICustomDomain01A52E88": {
+      "Properties": {
+        "DomainName": "pressreader.gutools.co.uk",
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL",
+          ],
+        },
+        "RegionalCertificateArn": {
+          "Ref": "CertificatePressreader5EF99BC2",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::DomainName",
+    },
+    "PressReaderAPICustomDomainMapPressReaderPressReaderAPI9C38AEB65FDBC78E": {
+      "Properties": {
+        "DomainName": {
+          "Ref": "PressReaderAPICustomDomain01A52E88",
+        },
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+        "Stage": {
+          "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
+        },
+      },
+      "Type": "AWS::ApiGateway::BasePathMapping",
+    },
+    "PressReaderAPIDeployment76372679e3895ad93ebdd14299f5c92e17122e30": {
       "DependsOn": [
         "PressReaderAPIdatakeyGET902D4076",
         "PressReaderAPIdatakey9D39D3B4",
@@ -256,7 +339,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment76372679b767bd6c2d07c973927fa790b7ede477",
+          "Ref": "PressReaderAPIDeployment76372679e3895ad93ebdd14299f5c92e17122e30",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -435,7 +518,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 {
                   "Ref": "PressreaderDataBucketPressreader48E10950",
                 },
-                "/data/{key}",
+                "/data/{key}.json",
               ],
             ],
           },
@@ -497,6 +580,23 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "cname": {
+      "Properties": {
+        "Name": "pressreader.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "PressReaderAPICustomDomain01A52E88",
+              "RegionalDomainName",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 86400,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "pressreaderlambdaB481BEF0": {
       "DependsOn": [

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -138,9 +138,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
     "PressReaderAPI27D6A559": {
       "Properties": {
-        "BinaryMediaTypes": [
-          "application/json",
-        ],
         "Description": "Serves data to Press Reader from an S3 bucket.",
         "MinimumCompressionSize": 0,
         "Name": "Press Reader API",
@@ -232,7 +229,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "PressReaderAPIDeployment763726798bf10020fb5e9c5cdf604cd172781332": {
+    "PressReaderAPIDeployment76372679e5f9cc7c2f05ed5f404ba8c9db4a6514": {
       "DependsOn": [
         "PressReaderAPIdatakeyGET902D4076",
         "PressReaderAPIdatakey9D39D3B4",
@@ -252,7 +249,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment763726798bf10020fb5e9c5cdf604cd172781332",
+          "Ref": "PressReaderAPIDeployment76372679e5f9cc7c2f05ed5f404ba8c9db4a6514",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -278,6 +275,78 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::Stage",
+    },
+    "PressReaderAPIPressReaderAPIUsagePlan5896C6C0": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Throttle": {
+          "RateLimit": 5,
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlan",
+    },
+    "PressReaderAPIPressReaderAPIUsagePlanUsagePlanKeyResourcePressReaderPressReaderAPIPressReaderClientApiKeyB938A4323A97BA22": {
+      "Properties": {
+        "KeyId": {
+          "Ref": "PressReaderAPIPressReaderClientApiKey193E0946",
+        },
+        "KeyType": "API_KEY",
+        "UsagePlanId": {
+          "Ref": "PressReaderAPIPressReaderAPIUsagePlan5896C6C0",
+        },
+      },
+      "Type": "AWS::ApiGateway::UsagePlanKey",
+    },
+    "PressReaderAPIPressReaderClientApiKey193E0946": {
+      "Properties": {
+        "Enabled": true,
+        "StageKeys": [
+          {
+            "RestApiId": {
+              "Ref": "PressReaderAPI27D6A559",
+            },
+            "StageName": {
+              "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::ApiKey",
     },
     "PressReaderAPIdata6C16C1E3": {
       "Properties": {
@@ -425,6 +494,59 @@ exports[`The PressReader stack matches the snapshot 1`] = `
             "APP": "pressreader",
             "BUCKET_NAME": {
               "Ref": "PressreaderDataBucketPressreader48E10950",
+            },
+            "CAPI_SECRET_LOCATION": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
             },
             "STACK": "print-production",
             "STAGE": "TEST",

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -10,6 +10,34 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     ],
     "gu:cdk:version": "TEST",
   },
+  "Outputs": {
+    "PressReaderAPIEndpointC91EED74": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "PressReaderAPI27D6A559",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "PressReaderAPIDeploymentStageprod36351D7E",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
   "Parameters": {
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -18,6 +46,68 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "ApiGatewayS3AssumeRoleC6FF4BBF": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "RoleName": "APIGatewayS3IntegrationRole",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiGatewayS3AssumeRoleDefaultPolicy523002C3": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:Get",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "PressreaderDataBucketPressreader48E10950",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiGatewayS3AssumeRoleDefaultPolicy523002C3",
+        "Roles": [
+          {
+            "Ref": "ApiGatewayS3AssumeRoleC6FF4BBF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "CapiTokenSecret1D3F4E33": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -45,6 +135,242 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "PressReaderAPI27D6A559": {
+      "Properties": {
+        "BinaryMediaTypes": [
+          "application/json",
+        ],
+        "Description": "Serves data to Press Reader from an S3 bucket.",
+        "MinimumCompressionSize": 0,
+        "Name": "Press Reader API",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "PressReaderAPIAccount0348D010": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "PressReaderAPI27D6A559",
+      ],
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "PressReaderAPICloudWatchRole11526889",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PressReaderAPICloudWatchRole11526889": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "PressReaderAPIDeployment763726798bf10020fb5e9c5cdf604cd172781332": {
+      "DependsOn": [
+        "PressReaderAPIdatakeyGET902D4076",
+        "PressReaderAPIdatakey9D39D3B4",
+        "PressReaderAPIdata6C16C1E3",
+      ],
+      "Properties": {
+        "Description": "Serves data to Press Reader from an S3 bucket.",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "PressReaderAPIDeploymentStageprod36351D7E": {
+      "DependsOn": [
+        "PressReaderAPIAccount0348D010",
+      ],
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "PressReaderAPIDeployment763726798bf10020fb5e9c5cdf604cd172781332",
+        },
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+        "StageName": "prod",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "PressReaderAPIdata6C16C1E3": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "PressReaderAPI27D6A559",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "data",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIdatakey9D39D3B4": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "PressReaderAPIdata6C16C1E3",
+        },
+        "PathPart": "{key}",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIdatakeyGET902D4076": {
+      "Properties": {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayS3AssumeRoleC6FF4BBF",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "GET",
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.path.key": "method.request.path.key",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":s3:path/",
+                {
+                  "Ref": "PressreaderDataBucketPressreader48E10950",
+                },
+                "/{key}",
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Type": true,
+            },
+            "StatusCode": "200",
+          },
+        ],
+        "RequestParameters": {
+          "method.request.header.Content-Type": true,
+          "method.request.path.key": true,
+        },
+        "ResourceId": {
+          "Ref": "PressReaderAPIdatakey9D39D3B4",
+        },
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
     "PressreaderDataBucketPressreader48E10950": {
       "DeletionPolicy": "Retain",

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -82,13 +82,15 @@ export class PressReader extends GuStack {
 					'method.request.path.key': true,
 					'method.request.header.Content-Type': true,
 				},
+				apiKeyRequired: true,
 			});
 
 		// create usage plan
 		const usagePlan = apiGateway.addUsagePlan('PressReaderAPIUsagePlan', {
 			throttle: {
 				// Maximum expected average requests per second
-				rateLimit: 25,
+				rateLimit: 10,
+				burstLimit: 10,
 			},
 		});
 
@@ -101,7 +103,7 @@ export class PressReader extends GuStack {
 		usagePlan.addApiKey(pressReaderClientApiKey);
 
 		// associate stage with plan
-		// usagePlan.addApiStage({ stage: apiGateway.deploymentStage });
+		usagePlan.addApiStage({ stage: apiGateway.deploymentStage });
 
 		// Secret
 		const capiSecret = new Secret(this, 'CapiTokenSecret', {

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -128,6 +128,7 @@ export class PressReader extends GuStack {
 				handler: 'handler.main',
 				environment: {
 					BUCKET_NAME: dataBucket.bucketName,
+					CAPI_SECRET_LOCATION: capiSecret.secretName,
 				},
 				fileName: `pressreader.zip`,
 				monitoringConfiguration: {

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -62,6 +62,7 @@ export class PressReader extends GuStack {
 					},
 				],
 				requestParameters: {
+					'integration.request.path.folder': 'method.request.path.folder',
 					'integration.request.path.key': 'method.request.path.key',
 				},
 			},
@@ -69,6 +70,7 @@ export class PressReader extends GuStack {
 
 		apiGateway.root
 			.addResource('data')
+			.addResource('{folder}')
 			.addResource('{key}')
 			.addMethod('GET', s3Integration, {
 				methodResponses: [
@@ -80,11 +82,13 @@ export class PressReader extends GuStack {
 					},
 				],
 				requestParameters: {
+					'method.request.path.folder': true,
 					'method.request.path.key': true,
 					'method.request.header.Content-Type': true,
 				},
 			});
 
+		// create usage plan
 		const usagePlan = apiGateway.addUsagePlan('PressReaderAPIUsagePlan', {
 			throttle: {
 				// Maximum expected average requests per second
@@ -92,11 +96,16 @@ export class PressReader extends GuStack {
 			},
 		});
 
+		// create api key
 		const pressReaderClientApiKey = apiGateway.addApiKey(
 			'PressReaderClientApiKey',
 		);
 
+		// associate api key to plan
 		usagePlan.addApiKey(pressReaderClientApiKey);
+
+		// associate stage with plan
+		usagePlan.addApiStage({ stage: apiGateway.deploymentStage });
 
 		// Secret
 		const capiSecret = new Secret(this, 'CapiTokenSecret', {

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -86,6 +86,19 @@ export class PressReader extends GuStack {
 				},
 			});
 
+		const usagePlan = apiGateway.addUsagePlan('PressReaderAPIUsagePlan', {
+			throttle: {
+				// Maximum expected average requests per second
+				rateLimit: 5,
+			},
+		});
+
+		const pressReaderClientApiKey = apiGateway.addApiKey(
+			'PressReaderClientApiKey',
+		);
+
+		usagePlan.addApiKey(pressReaderClientApiKey);
+
 		// Secret
 		const capiSecret = new Secret(this, 'CapiTokenSecret', {
 			secretName: `/${this.stage}/${this.stack}/${pressReaderApp}/capiToken`,

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -119,12 +119,7 @@ export class PressReader extends GuStack {
 		// associate stage with plan
 		usagePlan.addApiStage({ stage: apiGateway.deploymentStage });
 
-		// Secret
-		const capiSecret = new Secret(this, 'CapiTokenSecret', {
-			secretName: `/${this.stage}/${this.stack}/${pressReaderApp}/capiToken`,
-			description: 'The CAPI token used to retrieve content',
-		});
-
+		// domain name
 		const apiDomainName = apiGateway.domainName as DomainName;
 
 		new GuCname(this, 'cname', {
@@ -134,7 +129,13 @@ export class PressReader extends GuStack {
 			resourceRecord: apiDomainName.domainNameAliasDomainName,
 		});
 
-		// Scheduled Lambda
+		// secrets
+		const capiSecret = new Secret(this, 'CapiTokenSecret', {
+			secretName: `/${this.stage}/${this.stack}/${pressReaderApp}/capiToken`,
+			description: 'The CAPI token used to retrieve content',
+		});
+
+		// scheduled Lambda
 		const capiSecretGetPolicyStatement = new PolicyStatement({
 			effect: Effect.ALLOW,
 			actions: ['secretsmanager:GetSecretValue'],

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -31,7 +31,6 @@ export class PressReader extends GuStack {
 		const apiGateway = new RestApi(this, 'PressReaderAPI', {
 			restApiName: 'Press Reader API',
 			description: 'Serves data to Press Reader from an S3 bucket.',
-			binaryMediaTypes: ['application/json'],
 			minCompressionSize: Size.bytes(0),
 		});
 

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -4,26 +4,95 @@ import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
+import { AwsIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
 import { Schedule } from 'aws-cdk-lib/aws-events';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import {
+	Effect,
+	PolicyStatement,
+	Role,
+	ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { Size } from 'aws-cdk-lib/core';
 
 export class PressReader extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 		const pressReaderApp = 'pressreader';
 
+		// S3 Bucket
 		const dataBucket = new GuS3Bucket(this, 'PressreaderDataBucket', {
 			app: pressReaderApp,
 			bucketName: `gu-pressreader-data-${this.stage.toLowerCase()}`,
 		});
 
+		// API Gateway
+		const apiGateway = new RestApi(this, 'PressReaderAPI', {
+			restApiName: 'Press Reader API',
+			description: 'Serves data to Press Reader from an S3 bucket.',
+			binaryMediaTypes: ['application/json'],
+			minCompressionSize: Size.bytes(0),
+		});
+
+		const executeRole = new Role(this, 'ApiGatewayS3AssumeRole', {
+			assumedBy: new ServicePrincipal('apigateway.amazonaws.com'),
+			roleName: 'APIGatewayS3IntegrationRole',
+		});
+
+		executeRole.addToPolicy(
+			new PolicyStatement({
+				resources: [dataBucket.bucketArn],
+				actions: ['s3:Get'],
+			}),
+		);
+
+		const s3Integration = new AwsIntegration({
+			service: 's3',
+			integrationHttpMethod: 'GET',
+			path: `${dataBucket.bucketName}/{key}`,
+			options: {
+				credentialsRole: executeRole,
+				integrationResponses: [
+					{
+						statusCode: '200',
+						responseParameters: {
+							'method.response.header.Content-Type':
+								'integration.response.header.Content-Type',
+						},
+					},
+				],
+				requestParameters: {
+					'integration.request.path.key': 'method.request.path.key',
+				},
+			},
+		});
+
+		apiGateway.root
+			.addResource('data')
+			.addResource('{key}')
+			.addMethod('GET', s3Integration, {
+				methodResponses: [
+					{
+						statusCode: '200',
+						responseParameters: {
+							'method.response.header.Content-Type': true,
+						},
+					},
+				],
+				requestParameters: {
+					'method.request.path.key': true,
+					'method.request.header.Content-Type': true,
+				},
+			});
+
+		// Secret
 		const capiSecret = new Secret(this, 'CapiTokenSecret', {
 			secretName: `/${this.stage}/${this.stack}/${pressReaderApp}/capiToken`,
 			description: 'The CAPI token used to retrieve content',
 		});
 
+		// Scheduled Lambda
 		const capiSecretGetPolicyStatement = new PolicyStatement({
 			effect: Effect.ALLOW,
 			actions: ['secretsmanager:GetSecretValue'],

--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -13,7 +13,7 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 
 	const params = {
 		Bucket: bucketName,
-		Key: objectLocation,
+		Key: ['data', objectLocation].join('/'),
 		Body: dataToStore,
 		ContentType: 'application/json',
 	};


### PR DESCRIPTION
## What does this change?

This change adds an API Gateway Rest API, and utilises the S3 integration to allow serving files from the S3 bucket the scheduled lambda is writing to. This allows us to move towards removing public read buckets elsewhere.

There is [an ADR added in this change](https://github.com/guardian/pressreader/blob/rk/add-api-gateway/docs/adr/02-api-gateway.md) that describes the justification for this decision.

## How to test

Data from the API can be requested:

```sh
# Endpoint takes requests in the for /data/:date
# Where :date is in the format YYYYMMDD
curl -H "x-api-key: not-a-real-api-key" https://pressreader.gutools.co.uk/data/20230503
```
## How can we measure success?

Eventually Pressreader is able to use this API, and we can avoid any use of public S3 buckets.

## Have we considered potential risks?

Leak of an API key could result in unexpected spike in API usages, however request rates are throttled.