### PR TITLE
Add business logic to handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2188,6 +2188,46 @@
                 "constructs": "10.2.8"
             }
         },
+        "node_modules/@guardian/content-api-models": {
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/@guardian/content-api-models/-/content-api-models-17.6.2.tgz",
+            "integrity": "sha512-2mmlL9HX73b86EzYZqyYxiNlu4x2EoqWsMVt58vHIiM0QxEj0baQtD4H9bF8yq/hJ2BQKSHBrDnkW/Aak5Ojfg==",
+            "dev": true,
+            "dependencies": {
+                "@guardian/content-atom-model": "^3.4.2",
+                "@guardian/content-entity-model": "^2.2.1",
+                "@guardian/story-packages-model": "^2.2.0",
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
+        "node_modules/@guardian/content-atom-model": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@guardian/content-atom-model/-/content-atom-model-3.4.4.tgz",
+            "integrity": "sha512-OeLqmQODJPqSa9Y/RhLhJOTIYj0BK07tSZBn71QZ3OstQhcW2nZGxSCN9tbYLYHhj30Uzn6fsLwZcv4JlNTbtg==",
+            "dev": true,
+            "dependencies": {
+                "@guardian/content-entity-model": "^2.2.1",
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
+        "node_modules/@guardian/content-entity-model": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@guardian/content-entity-model/-/content-entity-model-2.2.1.tgz",
+            "integrity": "sha512-ywFYEmwvM8LcLxKbP321KqRGzd4lD40MNUCxS7V38eLbo6emgIJDmPl4rpNMgznR79BL5S1Q0FOhhRqChSVv/g==",
+            "dev": true,
+            "dependencies": {
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
         "node_modules/@guardian/eslint-config": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -2226,6 +2266,18 @@
             "dev": true,
             "peerDependencies": {
                 "prettier": "^2.4.0"
+            }
+        },
+        "node_modules/@guardian/story-packages-model": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@guardian/story-packages-model/-/story-packages-model-2.2.0.tgz",
+            "integrity": "sha512-tZWBvoBTfR9K7AGlhsiPYAefIjfA5NsU/65OhcZjBEiFN6J+ay37D1dH6uIghYZbd+fB0mQ0I9kT/ac4Lgx0yQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
             }
         },
         "node_modules/@guardian/tsconfig": {
@@ -3006,6 +3058,15 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
             "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg=="
         },
+        "node_modules/@types/node-int64": {
+            "version": "0.4.29",
+            "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",
+            "integrity": "sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -3016,6 +3077,12 @@
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+        },
+        "node_modules/@types/q": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
+            "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
+            "dev": true
         },
         "node_modules/@types/semver": {
             "version": "7.5.0",
@@ -3052,6 +3119,17 @@
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
             "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
+        },
+        "node_modules/@types/thrift": {
+            "version": "0.10.12",
+            "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.12.tgz",
+            "integrity": "sha512-5BIQz+lJDwFCsShtLVm2o/1oXrAps9aDd1czeMP0JvYzDQqZ3cRees8ahBkMR0AGIxZR+OFvcRe7GI/v+Udc4Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/node-int64": "*",
+                "@types/q": "*"
+            }
         },
         "node_modules/@types/yargs": {
             "version": "17.0.24",
@@ -3440,6 +3518,17 @@
             "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
             "dev": true
         },
+        "node_modules/async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
         "node_modules/at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3517,13 +3606,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
             "version": "1.0.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "Apache-2.0"
         },
         "node_modules/aws-cdk-lib/node_modules/ajv": {
             "version": "8.12.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3539,7 +3628,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3548,7 +3637,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3563,7 +3652,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/astral-regex": {
             "version": "2.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3572,7 +3661,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/at-least-node": {
             "version": "1.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -3581,13 +3670,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/balanced-match": {
             "version": "1.0.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3597,7 +3686,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/case": {
             "version": "1.6.3",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "(MIT OR GPL-3.0-or-later)",
             "engines": {
@@ -3606,7 +3695,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3618,31 +3707,31 @@
         },
         "node_modules/aws-cdk-lib/node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/concat-map": {
             "version": "0.0.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fs-extra": {
             "version": "9.1.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3657,13 +3746,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
             "version": "4.2.10",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/ignore": {
             "version": "5.2.4",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3672,7 +3761,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3681,13 +3770,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/jsonfile": {
             "version": "6.1.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3699,7 +3788,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/jsonschema": {
             "version": "1.4.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3708,13 +3797,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3726,7 +3815,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/minimatch": {
             "version": "3.1.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3738,7 +3827,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/punycode": {
             "version": "2.3.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3747,7 +3836,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/require-from-string": {
             "version": "2.0.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3756,7 +3845,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/semver": {
             "version": "7.3.8",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3771,7 +3860,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3788,7 +3877,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3802,7 +3891,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3814,7 +3903,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/table": {
             "version": "6.8.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3830,7 +3919,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/universalify": {
             "version": "2.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3839,7 +3928,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/uri-js": {
             "version": "4.4.1",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3848,13 +3937,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/yallist": {
             "version": "4.0.0",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/yaml": {
             "version": "1.10.2",
-            "dev": true,
+            "extraneous": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -3891,6 +3980,16 @@
                 "@types/sinon": "^10.0.10",
                 "sinon": "^14.0.2",
                 "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+            "dependencies": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/babel-jest": {
@@ -4058,6 +4157,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/browser-or-node": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
+            "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
+            "dev": true
         },
         "node_modules/browserslist": {
             "version": "4.21.5",
@@ -4396,6 +4501,17 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4651,6 +4767,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/detect-newline": {
@@ -5910,6 +6034,25 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/follow-redirects": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/for-each": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5917,6 +6060,19 @@
             "dev": true,
             "dependencies": {
                 "is-callable": "^1.1.3"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fs-extra": {
@@ -6773,6 +6929,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+        },
+        "node_modules/isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "dev": true,
+            "peerDependencies": {
+                "ws": "*"
+            }
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -7632,6 +7797,25 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -8279,6 +8463,11 @@
             "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
             "dev": true
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
         "node_modules/punycode": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -8303,6 +8492,16 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ]
+        },
+        "node_modules/q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.6.0",
+                "teleport": ">=0.2.0"
+            }
         },
         "node_modules/querystring": {
             "version": "0.2.0",
@@ -9028,6 +9227,22 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/thrift": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.15.0.tgz",
+            "integrity": "sha512-RvuFCwHD8bAHIh0Evlr+8QJui/zzistIj9k668jX6jGvDF1OyOmI5TvY+YnqI/VQxpiE2OCGucYJs/nz/CfldA==",
+            "dev": true,
+            "dependencies": {
+                "browser-or-node": "^1.2.1",
+                "isomorphic-ws": "^4.0.1",
+                "node-int64": "^0.4.0",
+                "q": "^1.5.0",
+                "ws": "^5.2.2"
+            },
+            "engines": {
+                "node": ">= 10.18.0"
+            }
+        },
         "node_modules/titleize": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -9617,6 +9832,15 @@
                 "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
+        "node_modules/ws": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+            "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+            "dev": true,
+            "dependencies": {
+                "async-limiter": "~1.0.0"
+            }
+        },
         "node_modules/xml2js": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -9728,11 +9952,13 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "axios": "1.4.0",
                 "ts-node-dev": "^2.0.0"
             },
             "devDependencies": {
                 "@aws-sdk/client-s3": "^3.337.0",
                 "@aws-sdk/client-secrets-manager": "^3.337.0",
+                "@guardian/content-api-models": "17.6.2",
                 "@types/node": "18.13.0"
             }
         },
@@ -11505,6 +11731,46 @@
                 "yargs": "^17.6.2"
             }
         },
+        "@guardian/content-api-models": {
+            "version": "17.6.2",
+            "resolved": "https://registry.npmjs.org/@guardian/content-api-models/-/content-api-models-17.6.2.tgz",
+            "integrity": "sha512-2mmlL9HX73b86EzYZqyYxiNlu4x2EoqWsMVt58vHIiM0QxEj0baQtD4H9bF8yq/hJ2BQKSHBrDnkW/Aak5Ojfg==",
+            "dev": true,
+            "requires": {
+                "@guardian/content-atom-model": "^3.4.2",
+                "@guardian/content-entity-model": "^2.2.1",
+                "@guardian/story-packages-model": "^2.2.0",
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
+        "@guardian/content-atom-model": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/@guardian/content-atom-model/-/content-atom-model-3.4.4.tgz",
+            "integrity": "sha512-OeLqmQODJPqSa9Y/RhLhJOTIYj0BK07tSZBn71QZ3OstQhcW2nZGxSCN9tbYLYHhj30Uzn6fsLwZcv4JlNTbtg==",
+            "dev": true,
+            "requires": {
+                "@guardian/content-entity-model": "^2.2.1",
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
+        "@guardian/content-entity-model": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@guardian/content-entity-model/-/content-entity-model-2.2.1.tgz",
+            "integrity": "sha512-ywFYEmwvM8LcLxKbP321KqRGzd4lD40MNUCxS7V38eLbo6emgIJDmPl4rpNMgznR79BL5S1Q0FOhhRqChSVv/g==",
+            "dev": true,
+            "requires": {
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
+        },
         "@guardian/eslint-config": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -11535,6 +11801,18 @@
             "integrity": "sha512-4fehERf5HHS9Nkaw+4u5EZ1OrFEHL4lYhLUWkpwEx4VmHI+RgcMezfDfosb3TD8cPFCKakrpdQEJUwNP283SJw==",
             "dev": true,
             "requires": {}
+        },
+        "@guardian/story-packages-model": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@guardian/story-packages-model/-/story-packages-model-2.2.0.tgz",
+            "integrity": "sha512-tZWBvoBTfR9K7AGlhsiPYAefIjfA5NsU/65OhcZjBEiFN6J+ay37D1dH6uIghYZbd+fB0mQ0I9kT/ac4Lgx0yQ==",
+            "dev": true,
+            "requires": {
+                "@types/node-int64": "^0.4.29",
+                "@types/thrift": "^0.10.11",
+                "node-int64": "^0.4.0",
+                "thrift": "^0.15.0"
+            }
         },
         "@guardian/tsconfig": {
             "version": "0.2.0",
@@ -12185,6 +12463,15 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
             "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg=="
         },
+        "@types/node-int64": {
+            "version": "0.4.29",
+            "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",
+            "integrity": "sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/normalize-package-data": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -12195,6 +12482,12 @@
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
             "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+        },
+        "@types/q": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
+            "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
+            "dev": true
         },
         "@types/semver": {
             "version": "7.5.0",
@@ -12231,6 +12524,17 @@
             "version": "0.0.30",
             "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
             "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
+        },
+        "@types/thrift": {
+            "version": "0.10.12",
+            "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.12.tgz",
+            "integrity": "sha512-5BIQz+lJDwFCsShtLVm2o/1oXrAps9aDd1czeMP0JvYzDQqZ3cRees8ahBkMR0AGIxZR+OFvcRe7GI/v+Udc4Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/node-int64": "*",
+                "@types/q": "*"
+            }
         },
         "@types/yargs": {
             "version": "17.0.24",
@@ -12475,6 +12779,17 @@
             "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
             "dev": true
         },
+        "async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
         "at-least-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -12520,12 +12835,12 @@
                 "@balena/dockerignore": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "ajv": {
                     "version": "8.12.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12536,12 +12851,12 @@
                 "ansi-regex": {
                     "version": "5.0.1",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "ansi-styles": {
                     "version": "4.3.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -12549,22 +12864,22 @@
                 "astral-regex": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "at-least-node": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "balanced-match": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -12573,12 +12888,12 @@
                 "case": {
                     "version": "1.6.3",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "color-convert": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -12586,27 +12901,27 @@
                 "color-name": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "fast-deep-equal": {
                     "version": "3.1.3",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "fs-extra": {
                     "version": "9.1.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
@@ -12617,27 +12932,27 @@
                 "graceful-fs": {
                     "version": "4.2.10",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "ignore": {
                     "version": "5.2.4",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "jsonfile": {
                     "version": "6.1.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "graceful-fs": "^4.1.6",
                         "universalify": "^2.0.0"
@@ -12646,17 +12961,17 @@
                 "jsonschema": {
                     "version": "1.4.1",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "lodash.truncate": {
                     "version": "4.4.2",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "yallist": "^4.0.0"
                     }
@@ -12664,7 +12979,7 @@
                 "minimatch": {
                     "version": "3.1.2",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -12672,17 +12987,17 @@
                 "punycode": {
                     "version": "2.3.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "require-from-string": {
                     "version": "2.0.2",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "semver": {
                     "version": "7.3.8",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -12690,7 +13005,7 @@
                 "slice-ansi": {
                     "version": "4.0.0",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "ansi-styles": "^4.0.0",
                         "astral-regex": "^2.0.0",
@@ -12700,7 +13015,7 @@
                 "string-width": {
                     "version": "4.2.3",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
@@ -12710,7 +13025,7 @@
                 "strip-ansi": {
                     "version": "6.0.1",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -12718,7 +13033,7 @@
                 "table": {
                     "version": "6.8.1",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "ajv": "^8.0.1",
                         "lodash.truncate": "^4.4.2",
@@ -12730,12 +13045,12 @@
                 "universalify": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "uri-js": {
                     "version": "4.4.1",
                     "bundled": true,
-                    "dev": true,
+                    "extraneous": true,
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -12743,12 +13058,12 @@
                 "yallist": {
                     "version": "4.0.0",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 },
                 "yaml": {
                     "version": "1.10.2",
                     "bundled": true,
-                    "dev": true
+                    "extraneous": true
                 }
             }
         },
@@ -12779,6 +13094,16 @@
                 "@types/sinon": "^10.0.10",
                 "sinon": "^14.0.2",
                 "tslib": "^2.1.0"
+            }
+        },
+        "axios": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+            "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+            "requires": {
+                "follow-redirects": "^1.15.0",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
             }
         },
         "babel-jest": {
@@ -12899,6 +13224,12 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "browser-or-node": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
+            "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
+            "dev": true
         },
         "browserslist": {
             "version": "4.21.5",
@@ -13147,6 +13478,14 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -13313,6 +13652,11 @@
                 "has-property-descriptors": "^1.0.0",
                 "object-keys": "^1.1.1"
             }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -14168,6 +14512,11 @@
             "dev": true,
             "peer": true
         },
+        "follow-redirects": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+        },
         "for-each": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -14175,6 +14524,16 @@
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
+            }
+        },
+        "form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
             }
         },
         "fs-extra": {
@@ -14756,6 +15115,13 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+        },
+        "isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+            "dev": true,
+            "requires": {}
         },
         "istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -15416,6 +15782,19 @@
                 "picomatch": "^2.3.1"
             }
         },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        },
         "mimic-fn": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -15852,7 +16231,9 @@
             "requires": {
                 "@aws-sdk/client-s3": "^3.337.0",
                 "@aws-sdk/client-secrets-manager": "^3.337.0",
+                "@guardian/content-api-models": "17.6.2",
                 "@types/node": "18.13.0",
+                "axios": "1.4.0",
                 "ts-node-dev": "^2.0.0"
             },
             "dependencies": {
@@ -15912,6 +16293,11 @@
             "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
             "dev": true
         },
+        "proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        },
         "punycode": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -15923,6 +16309,12 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
             "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ=="
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+            "dev": true
         },
         "querystring": {
             "version": "0.2.0",
@@ -16454,6 +16846,19 @@
             "dev": true,
             "peer": true
         },
+        "thrift": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.15.0.tgz",
+            "integrity": "sha512-RvuFCwHD8bAHIh0Evlr+8QJui/zzistIj9k668jX6jGvDF1OyOmI5TvY+YnqI/VQxpiE2OCGucYJs/nz/CfldA==",
+            "dev": true,
+            "requires": {
+                "browser-or-node": "^1.2.1",
+                "isomorphic-ws": "^4.0.1",
+                "node-int64": "^0.4.0",
+                "q": "^1.5.0",
+                "ws": "^5.2.2"
+            }
+        },
         "titleize": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -16864,6 +17269,15 @@
             "requires": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
+            }
+        },
+        "ws": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
+            "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
             }
         },
         "xml2js": {

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -1,30 +1,32 @@
 {
-  "name": "pressreader",
-  "version": "1.0.0",
-  "description": "",
-  "devDependencies": {
-    "@types/node": "18.13.0",
-    "@aws-sdk/client-s3": "^3.337.0",
-    "@aws-sdk/client-secrets-manager": "^3.337.0"
-  },
-  "scripts": {
-    "dev": "ts-node-dev --respawn src/handler.ts",
-    "typecheck": "tsc -noEmit",
-    "format": "prettier --write \"src/**/*.ts\"",
-    "build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:aws-sdk --platform=node",
-    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects pressreader"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/guardian/pressreader.git"
-  },
-  "author": "",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/guardian/pressreader/issues"
-  },
-  "homepage": "https://github.com/guardian/pressreader#readme",
-  "dependencies": {
-    "ts-node-dev": "^2.0.0"
-  }
+	"name": "pressreader",
+	"version": "1.0.0",
+	"description": "",
+	"devDependencies": {
+		"@aws-sdk/client-s3": "^3.337.0",
+		"@aws-sdk/client-secrets-manager": "^3.337.0",
+		"@guardian/content-api-models": "17.6.2",
+		"@types/node": "18.13.0"
+	},
+	"scripts": {
+		"dev": "ts-node-dev --respawn src/handler.ts",
+		"typecheck": "tsc -noEmit",
+		"format": "prettier --write \"src/**/*.ts\"",
+		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:aws-sdk --platform=node",
+		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects pressreader"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/guardian/pressreader.git"
+	},
+	"author": "",
+	"license": "Apache-2.0",
+	"bugs": {
+		"url": "https://github.com/guardian/pressreader/issues"
+	},
+	"homepage": "https://github.com/guardian/pressreader#readme",
+	"dependencies": {
+		"axios": "1.4.0",
+		"ts-node-dev": "^2.0.0"
+	}
 }

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -1,21 +1,6 @@
 import { editionConfig } from './config';
+import { editionProcessor } from './processEdition';
 import { getCapiToken, putDataToS3 } from './util';
-
-const fakeData = [
-	{
-		section: 'Headlines',
-		articles: [
-			'us-news/2017/oct/16/mitch-mcconnell-donald-trump-lunch-steve-bannon-war',
-			'world/2017/oct/17/murdered-panama-papers-journalist-son-malta-crooks-daphne-caruana-galizia',
-			'world/2017/oct/17/iraqi-forces-drive-kurdish-fighters-out-of-sinjar',
-			'world/2017/oct/17/un-report-on-rohingya-hunger-is-shelved-at-myanmars-request',
-			'us-news/2017/oct/17/florida-governor-state-of-emergency-richard-spencer-white-nationalist-speech',
-			'us-news/2017/oct/16/california-wildfire-death-toll-recovery',
-			'world/2017/oct/17/north-korean-un-envoy-says-nuclear-war-may-break-out-at-any-moment',
-			'world/2017/oct/17/anger-as-chinese-media-claim-harassment-is-just-a-western-problem',
-		],
-	},
-];
 
 export const main = async () => {
 	console.log('Lambda handler called, processing request');
@@ -27,11 +12,21 @@ export const main = async () => {
 	// TODO: Remove this log when consumed
 	console.log(`Got editionConfig: ${JSON.stringify(editionConfig)}`);
 
-	const dataToStore = JSON.stringify(fakeData);
+	const processor = editionProcessor({
+		edition: editionConfig,
+		capiConfig: {
+			capiKey: capiToken,
+			baseCapiUrl: 'https://content.guardianapis.com',
+		},
+	});
+
+	const data = await processor.run();
+	console.table(data);
+	const dataToStore = JSON.stringify(data);
+
 	const currentDate = new Date();
 
 	const writtenToLocation = await putDataToS3(dataToStore, currentDate);
-
 	console.log(`Written data to: ${writtenToLocation}`);
 };
 

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -21,7 +21,7 @@ export const main = async () => {
 	});
 
 	const data = await processor.run();
-	console.table(data);
+
 	const dataToStore = JSON.stringify(data);
 
 	const currentDate = new Date();

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -58,18 +58,21 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 				return { ...section, articleDetails };
 			}),
 		);
-		const USED_ARTICLE_IDS_STORE: string[] = [];
-		const OUTPUT_ACCUMULATOR: PressReaderEditionOutput = [];
+		/**
+		 * These two lists will be mutated in the loop below.
+		 */
+		const usedArticleIdsStore: string[] = [];
+		const outputAccumulator: PressReaderEditionOutput = [];
 		/**
 		 * Build up the list of articles for each section, checking that they
-		 * pass meet the criteria for inclusion, and also making sure that we
+		 * meet the criteria for inclusion, and also making sure that we
 		 * don't include the same article more than once in the edition.
 		 */
 		for (const section of sectionData) {
 			const articleIdsForSection = section.articleDetails
 				.filter((article) => {
 					return (
-						!USED_ARTICLE_IDS_STORE.includes(article.id) &&
+						!usedArticleIdsStore.includes(article.id) &&
 						meetsInclusionCriteria(
 							article,
 							edition.bannedTags ?? [],
@@ -79,13 +82,13 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 				})
 				.slice(0, section.maximumArticleCount + 1)
 				.map((article) => article.id);
-			USED_ARTICLE_IDS_STORE.push(...articleIdsForSection);
-			OUTPUT_ACCUMULATOR.push({
+			usedArticleIdsStore.push(...articleIdsForSection);
+			outputAccumulator.push({
 				section: section.displayName,
 				articles: articleIdsForSection,
 			});
 		}
-		return OUTPUT_ACCUMULATOR;
+		return outputAccumulator;
 	}
 }
 

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -28,17 +28,6 @@ type CapiConfig = {
 	capiKey: string;
 };
 
-function CapiSearchUrlFromQuery(query: string, capiConfig: CapiConfig): string {
-	return new URL(
-		`${query}&api-key=${capiConfig.capiKey}`,
-		capiConfig.baseCapiUrl,
-	).toString();
-}
-function CapiItemUrlFromId(id: string, capiConfig: CapiConfig): string {
-	const path = `${id}?show-tags=all&show-fields=wordcount&api-key=${capiConfig.capiKey}`;
-	return new URL(path, capiConfig.baseCapiUrl).toString();
-}
-
 export function editionProcessor({ edition, capiConfig }: Props) {
 	const MIN_WORDCOUNT = 200;
 
@@ -77,7 +66,11 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 				.filter((article) => {
 					return (
 						!USED_ARTICLE_IDS_STORE.includes(article.id) &&
-						isValidArticle(article, edition.bannedTags ?? [], MIN_WORDCOUNT)
+						meetsInclusionCriteria(
+							article,
+							edition.bannedTags ?? [],
+							MIN_WORDCOUNT,
+						)
 					);
 				})
 				.slice(0, section.maximumArticleCount + 1)
@@ -92,7 +85,19 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 	}
 }
 
-function isValidArticle(
+function CapiSearchUrlFromQuery(query: string, capiConfig: CapiConfig): string {
+	return new URL(
+		`${query}&api-key=${capiConfig.capiKey}`,
+		capiConfig.baseCapiUrl,
+	).toString();
+}
+
+function CapiItemUrlFromId(id: string, capiConfig: CapiConfig): string {
+	const path = `${id}?show-tags=all&show-fields=wordcount&api-key=${capiConfig.capiKey}`;
+	return new URL(path, capiConfig.baseCapiUrl).toString();
+}
+
+function meetsInclusionCriteria(
 	article: CapiItem,
 	bannedTags: string[],
 	minWordCount: number,

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -151,11 +151,13 @@ async function fetchArticleData(
 			return undefined;
 		}
 		throw new Error(
-			`CAPI error: ${data.message ?? 'no message set in CAPI response'}`,
+			`CAPI error: ${
+				data.message ?? 'no message set in CAPI response'
+			}. Requested item: ${id}`,
 		);
 	}
 	if (!isCapiItemResponse(data)) {
-		throw new Error(typeof data);
+		throw new Error(`CAPI response is not valid: ${id}`);
 	}
 	if (
 		data.content == undefined ||

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -1,0 +1,247 @@
+import axios from 'axios';
+import {
+	isCapiItemResponse,
+	isCapiSearchResponse,
+	isKnownCapiError,
+	isNotUndefined,
+	isPressedFrontPage,
+} from './typePredicates';
+import type { CapiItem } from './types/CapiTypes';
+import type { PressedFrontPage } from './types/PressedFrontTypes';
+import type {
+	FrontSource,
+	PressReaderEditionConfig,
+	PressReaderEditionOutput,
+} from './types/PressReaderTypes';
+
+interface FrontSourceWithData extends FrontSource {
+	data: PressedFrontPage;
+}
+
+type Props = {
+	edition: PressReaderEditionConfig;
+	capiConfig: CapiConfig;
+};
+
+type CapiConfig = {
+	baseCapiUrl: string;
+	capiKey: string;
+};
+
+function CapiSearchUrlFromQuery(query: string, capiConfig: CapiConfig): string {
+	return new URL(
+		`${query}&api-key=${capiConfig.capiKey}`,
+		capiConfig.baseCapiUrl,
+	).toString();
+}
+function CapiItemUrlFromId(id: string, capiConfig: CapiConfig): string {
+	const path = `${id}?show-tags=all&show-fields=wordcount&api-key=${capiConfig.capiKey}`;
+	return new URL(path, capiConfig.baseCapiUrl).toString();
+}
+
+export function editionProcessor({ edition, capiConfig }: Props) {
+	const MIN_WORDCOUNT = 200;
+
+	return { run };
+
+	async function run() {
+		const USED_ARTICLE_IDS_STORE: string[] = [];
+
+		const sectionData = await Promise.all(
+			edition.sections.map(async (section) => {
+				const frontArticleIds = await getArticleIdsFromFronts(
+					section.frontSources,
+				);
+				const capiArticleIds = await getArticleIdsFromCapi(
+					section.capiSources,
+					capiConfig,
+				);
+				/**
+				 * We can't guarantee that these ids are unique across the whole edition,
+				 * but we might as well remove duplicates within each section as we go,
+				 * to reduce calls to `fetchArticleData` below.
+				 */
+				const uniqueArticleIds = Array.from(
+					new Set([...frontArticleIds, ...capiArticleIds]),
+				);
+				const maybeArticles = await Promise.all(
+					uniqueArticleIds.map((id) => fetchArticleData(id, capiConfig)),
+				);
+				const articleDetails = maybeArticles.filter(isNotUndefined);
+				return { ...section, articleDetails };
+			}),
+		);
+		const OUTPUT_ACCUMULATOR: PressReaderEditionOutput = [];
+		for (const section of sectionData) {
+			const articleIdsForSection = section.articleDetails
+				.filter((article) => {
+					return (
+						!USED_ARTICLE_IDS_STORE.includes(article.id) &&
+						isValidArticle(article, edition.bannedTags ?? [], MIN_WORDCOUNT)
+					);
+				})
+				.slice(0, section.maximumArticleCount + 1)
+				.map((article) => article.id);
+			USED_ARTICLE_IDS_STORE.push(...articleIdsForSection);
+			OUTPUT_ACCUMULATOR.push({
+				section: section.displayName,
+				articles: articleIdsForSection,
+			});
+		}
+		return OUTPUT_ACCUMULATOR;
+	}
+}
+
+function isValidArticle(
+	article: CapiItem,
+	bannedTags: string[],
+	minWordCount: number,
+): boolean {
+	if (article.type != 'article') {
+		console.log(`Item excluded [Not Article]: ${article.id}`);
+		return false;
+	}
+	if (article.tags.some((tag) => bannedTags.includes(tag.id))) {
+		console.log(`Article excluded [Banned Tags]: ${article.id}`);
+
+		return false;
+	}
+	const publicationDate = new Date(article.webPublicationDate.iso8601);
+	const now = new Date();
+	if (publicationDate.getTime() < now.getTime() - 24 * 60 * 60 * 1000) {
+		console.log(`Article excluded [Too Old]: ${article.id}`);
+
+		return false;
+	}
+	if (article.wordcount <= minWordCount) {
+		console.log(`Article excluded [Too Short]: ${article.id}`);
+		return false;
+	}
+	return true;
+}
+
+async function fetchArticleData(
+	id: string,
+	capiConfig: CapiConfig,
+): Promise<CapiItem | undefined> {
+	const url = CapiItemUrlFromId(id, capiConfig);
+	const resp = await axios.get(url);
+	if (resp.status != 200) {
+		throw new Error('Failed to fetch article data');
+	}
+	const { response: data } = (await resp.data) as unknown as {
+		response: unknown;
+	};
+	/**
+	 * One known error is when the article exists but the API key does not
+	 * carry the right permissions to access it. We can't know whether an
+	 * article falls into this category beforehand, but this shouldn't
+	 * be a treated as a fatal error.
+	 */
+	if (isKnownCapiError(data)) {
+		if (
+			data.message ==
+			'You are not permitted to access this content via your current user tier.'
+		) {
+			return undefined;
+		}
+		throw new Error(
+			`CAPI error: ${data.message ?? 'no message set in CAPI response'}`,
+		);
+	}
+	if (!isCapiItemResponse(data)) {
+		throw new Error(typeof data);
+	}
+	if (
+		data.content == undefined ||
+		data.content.webPublicationDate == undefined ||
+		data.content.fields?.wordcount == undefined
+	) {
+		throw new Error('CAPI item is missing required fields');
+	}
+	try {
+		const wordcount = parseInt(
+			data.content.fields.wordcount as unknown as string,
+		);
+		const type = data.content.type as unknown as string;
+		return { ...data.content, wordcount, type } as CapiItem;
+	} catch (e) {
+		throw new Error('CAPI item has invalid wordcount value');
+	}
+}
+
+async function getArticleIdsFromCapi(
+	capiSourceUrls: string[],
+	capiConfig: CapiConfig,
+): Promise<string[]> {
+	const capiData = await Promise.all(
+		capiSourceUrls.map((query) => fetchCapiSearchData(query, capiConfig)),
+	);
+	return capiData.flat();
+}
+
+async function fetchCapiSearchData(
+	query: string,
+	capiConfig: CapiConfig,
+): Promise<string[]> {
+	const url = CapiSearchUrlFromQuery(query, capiConfig);
+	const response = await axios.get(url);
+	if (response.status != 200) {
+		console.log(`Capi search returned no data: ${query}`);
+		return [];
+	}
+	const data = (await response.data) as unknown;
+	if (!isCapiSearchResponse(data)) {
+		console.log(`Capi search returned invalid response: ${query})}`);
+		return [];
+	}
+	return data.response.results.map((article) => article.id);
+}
+
+async function getArticleIdsFromFronts(
+	frontSources: FrontSource[],
+): Promise<string[]> {
+	const frontData = await Promise.all(frontSources.map(fetchFrontData));
+	return frontData.filter(isNotUndefined).flatMap(processFrontData);
+}
+
+async function fetchFrontData(
+	front: FrontSource,
+): Promise<FrontSourceWithData | undefined> {
+	const response = await axios.get(front.sectionContentURL);
+	if (response.status != 200) {
+		console.log(
+			`Front source error [${response.status}]: ${front.sectionContentURL}`,
+		);
+		return undefined;
+	}
+	const data = (await response.data) as unknown;
+	if (!isPressedFrontPage(data)) {
+		console.log(
+			`Front source returned invalid response: ${front.sectionContentURL}`,
+		);
+		return undefined;
+	}
+	if (data.collections.length === 0) {
+		console.log(`Front source has no collections: ${front.sectionContentURL}`);
+		return undefined;
+	}
+	return {
+		...front,
+		data,
+	};
+}
+
+function processFrontData(front: FrontSourceWithData): string[] {
+	const collections = front.data.collections.filter((collection, index) => {
+		const targetNames = front.collectionNames.map((name) => name.toLowerCase());
+		return (
+			front.collectionIndexes.includes(index) ||
+			targetNames.includes(collection.displayName.toLowerCase())
+		);
+	});
+	const articles = collections.flatMap((collection) => {
+		return collection.content.map((article) => article.id);
+	});
+	return articles;
+}

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -34,8 +34,6 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 	return { run };
 
 	async function run() {
-		const USED_ARTICLE_IDS_STORE: string[] = [];
-
 		const sectionData = await Promise.all(
 			edition.sections.map(async (section) => {
 				const frontArticleIds = await getArticleIdsFromFronts(
@@ -60,7 +58,13 @@ export function editionProcessor({ edition, capiConfig }: Props) {
 				return { ...section, articleDetails };
 			}),
 		);
+		const USED_ARTICLE_IDS_STORE: string[] = [];
 		const OUTPUT_ACCUMULATOR: PressReaderEditionOutput = [];
+		/**
+		 * Build up the list of articles for each section, checking that they
+		 * pass meet the criteria for inclusion, and also making sure that we
+		 * don't include the same article more than once in the edition.
+		 */
 		for (const section of sectionData) {
 			const articleIdsForSection = section.articleDetails
 				.filter((article) => {

--- a/packages/pressreader/src/typePredicates.ts
+++ b/packages/pressreader/src/typePredicates.ts
@@ -1,0 +1,52 @@
+import type { ItemResponse } from '@guardian/content-api-models/v1/itemResponse';
+import type { CapiSearchResponse } from './types/CapiTypes';
+import type { PressedFrontPage } from './types/PressedFrontTypes';
+
+export function isCapiSearchResponse(
+	data: unknown,
+): data is CapiSearchResponse {
+	// Check that the candidate is an object
+	return (
+		data != null &&
+		(typeof data === 'object' || typeof data === 'function') &&
+		// this is a type predicate and casting is recommended by the docs: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
+		(data as CapiSearchResponse).response !== undefined &&
+		// this is a type predicate and casting is recommended by the docs: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
+		(data as CapiSearchResponse).response.results !== undefined
+	);
+}
+
+export function isPressedFrontPage(data: unknown): data is PressedFrontPage {
+	// Check that the candidate is an object
+	return (
+		data != null &&
+		(typeof data === 'object' || typeof data === 'function') &&
+		// this is a type predicate and casting is recommended by the docs: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
+		(data as PressedFrontPage).webTitle !== undefined
+	);
+}
+
+export function isNotUndefined<T>(value: T | undefined): value is T {
+	return value !== undefined;
+}
+
+export function isCapiItemResponse(data: unknown): data is ItemResponse {
+	return (
+		data != null &&
+		(typeof data === 'object' || typeof data === 'function') &&
+		(data as ItemResponse).status == 'ok'
+	);
+}
+
+export function isKnownCapiError(
+	data: unknown,
+): data is { status: 'error'; message?: string } {
+	return (
+		data != null &&
+		(typeof data === 'object' || typeof data === 'function') &&
+		(data as { status: string }).status == 'error'
+	);
+}

--- a/packages/pressreader/src/types/CapiTypes.ts
+++ b/packages/pressreader/src/types/CapiTypes.ts
@@ -1,0 +1,16 @@
+import type { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime';
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+
+export interface CapiSearchResponse {
+	response: {
+		results: Array<{ id: string; type: 'article' }>;
+	};
+}
+
+export interface CapiItem {
+	id: string;
+	type: string;
+	webPublicationDate: CapiDateTime;
+	tags: Tag[];
+	wordcount: number;
+}

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -18,7 +18,7 @@ export interface SectionConfig {
 	frontSources: FrontSource[];
 	/**
 	 * URLs for CAPI queries to be used as backfills for this section.
-	 * @example `["http://content.guardianapis.com/search?tag=science%2Fscience&production-office=us&order-by=newest&api-key=XXXXXXXXX"]`
+	 * @example `["search?tag=science%2Fscience&production-office=us&order-by=newest"]`
 	 */
 	capiSources: string[];
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

An initial pass at implementing the business logic for the pressreader job.

1. Take a config file that specifies a list of 'sections'.
2. Fetch the fronts collections and CAPI backfill searches for each section.
3. Fetch details for each article that was returned by step (2).
4. Check the articles for eligibility:
    - Exceeds a minimum wordcount.
    - Was published in the last 24 hours.
    - Doesn't include any 'banned' tags.
    - Hasn't already been included in another section of this edition.

It then returns a list of sections and article ids, to be saved to S3 by the handler function.

## How to test

- Set a CAPI api key in `resources.sh` (but make sure not to commit this!)
- Run `npm run dev`.
- Output should be generated for the example config in `config.ts`.

## How can we measure success?

This is part of migrating the existing service from on-prem to AWS Lambda.

