### PR TITLE
Rename and add output types

### DIFF
--- a/packages/pressreader/src/config.ts
+++ b/packages/pressreader/src/config.ts
@@ -1,4 +1,4 @@
-import type { PressReaderEditionConfig } from './types/PressReaderConfigTypes';
+import type { PressReaderEditionConfig } from './types/PressReaderTypes';
 
 export const editionConfig: PressReaderEditionConfig = {
 	sections: [
@@ -15,5 +15,43 @@ export const editionConfig: PressReaderEditionConfig = {
 			],
 			capiSources: [],
 		},
+		{
+			displayName: 'News',
+			maximumArticleCount: 14,
+			frontSources: [
+				{
+					collectionIndexes: [1],
+					collectionNames: ['Australia news'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['Across the country'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/au/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Politics',
+			maximumArticleCount: 8,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['Australian politics'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+				},
+			],
+			capiSources: [
+				'search?tag=australia-news%2Faustralian-politics&order-by=newest',
+			],
+		},
+	],
+	bannedTags: [
+		'sport/series/talking-horses',
+		'science/series/alex-bellos-monday-puzzle',
 	],
 };

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -1,5 +1,5 @@
 export interface PressReaderEditionConfig {
-	sections: Section[];
+	sections: SectionConfig[];
 	/**
 	 * A list of CAPI tags that is used to filter out articles from the section.
 	 * If an article has any of these tags, it will not be displayed.
@@ -8,7 +8,7 @@ export interface PressReaderEditionConfig {
 	bannedTags?: string[];
 }
 
-export interface Section {
+export interface SectionConfig {
 	/**
 	 * The name we are giving to this section (doesn't need to correspond to anything in
 	 * the pressed front json, but should be unique across all sections)
@@ -40,4 +40,11 @@ export interface FrontSource {
 	 * @example `"http://api.nextgen.guardianapps.co.uk/science/lite.json"`
 	 */
 	sectionContentURL: string;
+}
+
+export type PressReaderEditionOutput = PressReaderSectionOutput[];
+
+interface PressReaderSectionOutput {
+	section: string;
+	articles: string[];
 }

--- a/packages/pressreader/src/types/PressedFrontTypes.ts
+++ b/packages/pressreader/src/types/PressedFrontTypes.ts
@@ -14,7 +14,7 @@ interface CollectionType {
 	content: ContentType[];
 }
 
-interface ContentType {
+export interface ContentType {
 	id: string;
 	headline: string;
 	trailText: string;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add types for the expected output shape for the pressreader lambda. Also renames the existing `Section` type to make it clearer that it holds config for a section, not the output content for a section.
- Exports `ContentType`. It isn't actually imported in the current branch, but this PR is cherry-picked from a much larger PR where it will be imported. (I'm trying to reduce the number of files that are changed in that main PR.)
- Adds a couple of extra sections to the config fixture; this enables us to test with CAPI sources and deduping etc.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

