### PR TITLE
Add monitoring config, update docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,3 +17,9 @@ which is extended from the [AWS Cloud Development Kit (CDK)](https://aws.amazon.
 
 ![Pressreader architecture](./pressreader-arch-230523.png)
 [LucidChart Link](https://lucid.app/lucidchart/4040f7d6-661a-4867-ade0-93ca657a5580/edit?viewport_loc=-103%2C-73%2C1859%2C946%2C0_0&invitationId=inv_0cb12b70-eb29-4a54-8838-b4d32e07d820)
+
+## Logs & Monitoring
+
+Lambda logs can be viewed using the [`app: pressreader` filter in Kibana on logs.gutools.co.uk](https://logs.gutools.co.uk/s/newsroom-resilience/goto/8f38a860-fb94-11ed-a6e5-05ce52e0b77b).
+
+Monitoring on lambda errors is configured in [`./cdk/lib/pressreader.ts`](../packages/cdk/lib/pressreader.ts#L141), and will send alarm events to `newsroom.resilience+alerts@guardian.co.uk`.

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -9,6 +9,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "GuCname",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -598,6 +599,39 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
+    "pressreaderemailalarmtopic5E019B49": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "pressreaderemailalarmtopicnewsroomresiliencealertsguardiancoukC7FA91A6": {
+      "Properties": {
+        "Endpoint": "newsroom.resilience+alerts@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "pressreaderemailalarmtopic5E019B49",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "pressreaderlambdaB481BEF0": {
       "DependsOn": [
         "pressreaderlambdaServiceRoleDefaultPolicy7471EACC",
@@ -707,6 +741,99 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderlambdaErrorPercentageAlarmForLambda62A3B054": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderlambdaB481BEF0",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderlambdaB481BEF0",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderlambdaB481BEF0",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "pressreaderlambdaServiceRole68181491": {
       "Properties": {


### PR DESCRIPTION
## What does this change?

Adds monitoring to this lambda to notify `newsroom.resilience+alerts@guardian.co.uk` if there is an error in 2 consecutive runs of the lambda.

## How to test

The error state of the alarm can be set artificially to test if the expected email gets sent.

## How can we measure success?

We are notified of errors in `pressreader` runs and can fix things before people notice anything wrong.