### PR TITLE
Tests: article inclusion function

### DIFF
--- a/packages/pressreader/src/meetsInclusionCriteria.test.ts
+++ b/packages/pressreader/src/meetsInclusionCriteria.test.ts
@@ -38,6 +38,14 @@ describe('meetsInclusionCriteria', () => {
 		).toBe(true);
 	});
 
+	it('should return false if the item is not an article', () => {
+		const article: CapiItem = { ...passingArticle, type: '' };
+		const bannedTags: string[] = [];
+		expect(meetsInclusionCriteria(article, bannedTags, minWordCount)).toBe(
+			false,
+		);
+	});
+
 	it('should return false if the article was published more than 24 hours ago', () => {
 		const article: CapiItem = {
 			...passingArticle,

--- a/packages/pressreader/src/meetsInclusionCriteria.test.ts
+++ b/packages/pressreader/src/meetsInclusionCriteria.test.ts
@@ -1,0 +1,83 @@
+import type { Tag } from '@guardian/content-api-models/v1/tag';
+import { TagType } from '@guardian/content-api-models/v1/tagType';
+import { meetsInclusionCriteria } from './processEdition';
+import type { CapiItem } from './types/CapiTypes';
+
+const mockNow = '2023-05-22T05:00:47Z';
+const lessThan24HoursAgo = '2023-05-21T05:00:49Z';
+const moreThan24HoursAgo = '2023-05-21T05:00:46Z';
+const minWordCount = 1000;
+
+const dummyTag: Tag = {
+	id: '',
+	type: TagType.KEYWORD,
+	webTitle: '',
+	webUrl: '',
+	apiUrl: '',
+	references: [],
+};
+
+const passingArticle: CapiItem = {
+	id: '123',
+	type: 'article',
+	webPublicationDate: lessThan24HoursAgo,
+	wordcount: 1100,
+	tags: [],
+};
+
+beforeEach(() => {
+	jest.useFakeTimers();
+	jest.setSystemTime(new Date(mockNow));
+});
+
+describe('meetsInclusionCriteria', () => {
+	it('should return true if the article meets all the criteria', () => {
+		const bannedTags: string[] = [];
+		expect(
+			meetsInclusionCriteria(passingArticle, bannedTags, minWordCount),
+		).toBe(true);
+	});
+
+	it('should return false if the article was published more than 24 hours ago', () => {
+		const article: CapiItem = {
+			...passingArticle,
+			webPublicationDate: moreThan24HoursAgo,
+		};
+		const bannedTags: string[] = [];
+		expect(meetsInclusionCriteria(article, bannedTags, minWordCount)).toBe(
+			false,
+		);
+	});
+
+	it("should return false if the article's wordcount is smaller than the minimum wordcount", () => {
+		const article: CapiItem = { ...passingArticle, wordcount: 900 };
+		const bannedTags: string[] = [];
+		expect(meetsInclusionCriteria(article, bannedTags, minWordCount)).toBe(
+			false,
+		);
+	});
+
+	it("should return false if the article has tags that are included in the 'bannedTags' list", () => {
+		const tag = { ...dummyTag, id: 'aa' };
+		const article: CapiItem = { ...passingArticle, tags: [tag] };
+		const bannedTags: string[] = ['aa', 'bb', 'cc'];
+		expect(meetsInclusionCriteria(article, bannedTags, minWordCount)).toBe(
+			false,
+		);
+	});
+
+	it('should return false if more than one criterion is unmet', () => {
+		const tag = { ...dummyTag, id: 'aa' };
+		const article: CapiItem = {
+			id: '4',
+			webPublicationDate: moreThan24HoursAgo,
+			wordcount: 10,
+			tags: [tag],
+			type: 'article',
+		};
+		const bannedTags: string[] = ['aa'];
+		expect(meetsInclusionCriteria(article, bannedTags, minWordCount)).toBe(
+			false,
+		);
+	});
+});

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -104,7 +104,7 @@ function CapiItemUrlFromId(id: string, capiConfig: CapiConfig): string {
 	return new URL(path, capiConfig.baseCapiUrl).toString();
 }
 
-function meetsInclusionCriteria(
+export function meetsInclusionCriteria(
 	article: CapiItem,
 	bannedTags: string[],
 	minWordCount: number,
@@ -118,7 +118,7 @@ function meetsInclusionCriteria(
 
 		return false;
 	}
-	const publicationDate = new Date(article.webPublicationDate.iso8601);
+	const publicationDate = new Date(article.webPublicationDate);
 	const now = new Date();
 	if (publicationDate.getTime() < now.getTime() - 24 * 60 * 60 * 1000) {
 		console.log(`Article excluded [Too Old]: ${article.id}`);
@@ -178,7 +178,9 @@ async function fetchArticleData(
 			data.content.fields.wordcount as unknown as string,
 		);
 		const type = data.content.type as unknown as string;
-		return { ...data.content, wordcount, type } as CapiItem;
+		const webPublicationDate = data.content
+			.webPublicationDate as unknown as string;
+		return { ...data.content, webPublicationDate, wordcount, type } as CapiItem;
 	} catch (e) {
 		throw new Error('CAPI item has invalid wordcount value');
 	}

--- a/packages/pressreader/src/types/CapiTypes.ts
+++ b/packages/pressreader/src/types/CapiTypes.ts
@@ -1,4 +1,3 @@
-import type { CapiDateTime } from '@guardian/content-api-models/v1/capiDateTime';
 import type { Tag } from '@guardian/content-api-models/v1/tag';
 
 export interface CapiSearchResponse {
@@ -10,7 +9,7 @@ export interface CapiSearchResponse {
 export interface CapiItem {
 	id: string;
 	type: string;
-	webPublicationDate: CapiDateTime;
+	webPublicationDate: string;
 	tags: Tag[];
 	wordcount: number;
 }


### PR DESCRIPTION
Add automated tests for the main cases covered by the `meetsInclusionCriteria` function.

While adding these I realised that there was an error in the CAPI model types which was leading to the `webPublicationDate` of articles being accessed incorrectly. This commit also fixes that bug.

## How to test

Run `npm run test` in the terminal.

## How can we measure success?

The logic for this function can be changed in the future with greater confidence.

