### PR TITLE
Unit tests for processFrontData

### DIFF
--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -246,7 +246,7 @@ async function fetchFrontData(
 	};
 }
 
-function processFrontData(front: FrontSourceWithData): string[] {
+export function processFrontData(front: FrontSourceWithData): string[] {
 	const collections = front.data.collections.filter((collection, index) => {
 		const targetNames = front.collectionNames.map((name) => name.toLowerCase());
 		return (

--- a/packages/pressreader/src/processFrontData.test.ts
+++ b/packages/pressreader/src/processFrontData.test.ts
@@ -1,0 +1,99 @@
+import { processFrontData } from './processEdition';
+import type { PressedFrontPage } from './types/PressedFrontTypes';
+
+const dummyContentTemplate = {
+	id: 'string',
+	headline: 'string',
+	trailText: 'string',
+	thumbnail: 'string',
+	shortUrl: 'string',
+	group: 'string',
+};
+
+const content1 = {
+	...dummyContentTemplate,
+	id: '1',
+};
+
+const content2 = {
+	...dummyContentTemplate,
+	id: '2',
+};
+
+const content3 = {
+	...dummyContentTemplate,
+	id: '3',
+};
+
+const collection1 = {
+	id: 'abc',
+	displayName: 'name',
+	content: [content1, content2],
+};
+const collection2 = {
+	id: 'def',
+	displayName: 'my container',
+	content: [content3],
+};
+
+const pressedPage: PressedFrontPage = {
+	webTitle: 'Title',
+	collections: [collection1, collection2],
+};
+
+describe('processFrontData', () => {
+	it('should get stories from each of the matching collections', () => {
+		const frontConfigWithData = {
+			collectionIndexes: [0],
+			collectionNames: ['my container'],
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPage,
+		};
+		expect(processFrontData(frontConfigWithData)).toEqual(['1', '2', '3']);
+	});
+
+	it('should match a collection by name even if capitalisation differs', () => {
+		const frontConfigWithData = {
+			collectionIndexes: [],
+			collectionNames: ['My Container'],
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPage,
+		};
+		expect(processFrontData(frontConfigWithData)).toEqual(['3']);
+	});
+
+	it('should ignore unmatched collections', () => {
+		const frontConfigWithData = {
+			collectionIndexes: [],
+			collectionNames: ['not a match'],
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPage,
+		};
+		expect(processFrontData(frontConfigWithData)).toEqual([]);
+	});
+
+	it('should deduplicated stories using their id', () => {
+		const pressedPageWithDuplicate = {
+			...pressedPage,
+			collections: [
+				...pressedPage.collections,
+				{
+					id: 'ghi',
+					displayName: 'name',
+					content: [content3, { ...dummyContentTemplate, id: '4' }],
+				},
+			],
+		};
+
+		const frontConfigWithData = {
+			collectionIndexes: [2, 3],
+			collectionNames: [],
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPageWithDuplicate,
+		};
+		/**
+		 * If we didn't deduplicate, we'd expect to see '3' twice in this list.
+		 */
+		expect(processFrontData(frontConfigWithData)).toEqual(['3', '4']);
+	});
+});


### PR DESCRIPTION

## What does this change?

Adds Jest test cases to cover the main functionality of the `processFrontData` function.

## How to test

`npm run test`

## How can we measure success?

Catch errors earlier; make changes with greater confidence.

## Have we considered potential risks?

Flaky tests come with maintenance overhead, so I've tried to keep the tests fairly minimal and robust.
