### PR TITLE
Unit Tests: Type Predicates

### DIFF
--- a/packages/pressreader/src/typePredicates.test.ts
+++ b/packages/pressreader/src/typePredicates.test.ts
@@ -1,0 +1,66 @@
+import {
+	isCapiItemResponse,
+	isCapiSearchResponse,
+	isPressedFrontPage,
+} from './typePredicates';
+
+describe('isCapiItemResponse', () => {
+	it('should return true if the data has {status: "okay"}', () => {
+		expect(isCapiItemResponse({ status: 'ok' })).toBe(true);
+	});
+	it('should return false if the data does not have {status: "okay"}', () => {
+		expect(isCapiItemResponse({ status: 'error' })).toBe(false);
+	});
+	it('should return false if the data is an empty object', () => {
+		expect(isCapiItemResponse({})).toBe(false);
+	});
+	it('should return false if the data is not an object', () => {
+		expect(isCapiItemResponse([])).toBe(false);
+		expect(isCapiItemResponse(null)).toBe(false);
+		expect(isCapiItemResponse(undefined)).toBe(false);
+		expect(isCapiItemResponse(0)).toBe(false);
+		expect(isCapiItemResponse('')).toBe(false);
+	});
+});
+
+describe('isCapiSearchResponse', () => {
+	it('should return true if the data has {response: {results: []}}', () => {
+		expect(isCapiSearchResponse({ response: { results: [] } })).toBe(true);
+	});
+	it('should return false if the data does not have `response` key', () => {
+		expect(isCapiSearchResponse({ results: [] })).toBe(false);
+	});
+	it('should return false if the data does not have {response: {results: []}}', () => {
+		expect(isCapiSearchResponse({ response: '' })).toBe(false);
+		expect(isCapiSearchResponse({ response: { results: null } })).toBe(false);
+	});
+	it('should return false if the data is an empty object', () => {
+		expect(isCapiSearchResponse({})).toBe(false);
+	});
+	it('should return false if the data is not an object', () => {
+		expect(isCapiSearchResponse([])).toBe(false);
+		expect(isCapiSearchResponse(null)).toBe(false);
+		expect(isCapiSearchResponse(undefined)).toBe(false);
+		expect(isCapiSearchResponse(0)).toBe(false);
+		expect(isCapiSearchResponse('')).toBe(false);
+	});
+});
+
+describe('isPressedFrontPage', () => {
+	it('should return true if the data has `webTitle` property', () => {
+		expect(isPressedFrontPage({ webTitle: '' })).toBe(true);
+	});
+	it('should return false if the data does not have `webTitle` property', () => {
+		expect(isPressedFrontPage({ title: '' })).toBe(false);
+	});
+	it('should return false if the data is an empty object', () => {
+		expect(isPressedFrontPage({})).toBe(false);
+	});
+	it('should return false if the data is not an object', () => {
+		expect(isPressedFrontPage([])).toBe(false);
+		expect(isPressedFrontPage(null)).toBe(false);
+		expect(isPressedFrontPage(undefined)).toBe(false);
+		expect(isPressedFrontPage(0)).toBe(false);
+		expect(isPressedFrontPage('webTitle')).toBe(false);
+	});
+});

--- a/packages/pressreader/src/typePredicates.ts
+++ b/packages/pressreader/src/typePredicates.ts
@@ -12,9 +12,7 @@ export function isCapiSearchResponse(
 		// this is a type predicate and casting is recommended by the docs: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
 		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
 		(data as CapiSearchResponse).response !== undefined &&
-		// this is a type predicate and casting is recommended by the docs: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- see comment above
-		(data as CapiSearchResponse).response.results !== undefined
+		Array.isArray((data as CapiSearchResponse).response.results)
 	);
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Unit testing some of the more complicated type predicate functions. nb. these functions don't try to check every expected property of the relevant types. Rather, it takes the approach of verifying that some key indicative properties are present, and trusts that the CAPI models will be accurate for the rest of the properties if the tested properties are present.

I did want to check that they wouldn't crash if given unexpected inputs though.

## How to test

`npm run test`
