### PR TITLE
Use correct function for day-of-month

### DIFF
--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -7,7 +7,7 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 	const objectLocation = [
 		date.getFullYear(),
 		(date.getMonth() + 1).toString().padStart(2, '0'),
-		date.getDay().toString().padStart(2, '0'),
+		date.getDate().toString().padStart(2, '0'),
 		'.json',
 	].join('');
 


### PR DESCRIPTION

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use `getDate` instead of `getDay` for the name of the JSON file that we're saving to S3.

Docs for the JS Date function:

```ts
/** Gets the day-of-the-month, using local time. */
getDate(): number;
/** Gets the day of the week, using local time. */
getDay(): number;
```

I'm still not sure how we want to handle timezone localisation, but I think that's a separate issue.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How can we measure success?

We keep the same filename format that's used in the existing system.

