### PR TITLE
Add editionId to Edition config and S3 path

### DIFF
--- a/packages/pressreader/src/config.ts
+++ b/packages/pressreader/src/config.ts
@@ -1,6 +1,7 @@
 import type { PressReaderEditionConfig } from './types/PressReaderTypes';
 
 export const editionConfig: PressReaderEditionConfig = {
+	editionId: 'AUS',
 	sections: [
 		{
 			displayName: 'Headlines',

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -26,7 +26,11 @@ export const main = async () => {
 
 	const currentDate = new Date();
 
-	const writtenToLocation = await putDataToS3(dataToStore, currentDate);
+	const writtenToLocation = await putDataToS3(
+		dataToStore,
+		currentDate,
+		editionConfig.editionId,
+	);
 	console.log(`Written data to: ${writtenToLocation}`);
 };
 

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -1,4 +1,9 @@
 export interface PressReaderEditionConfig {
+	/**
+	 * A unique ID which can be used to identify the edition, which will be used
+	 * as part of the key in the S3 bucket where we store the edition outputs.
+	 */
+	editionId: string;
 	sections: SectionConfig[];
 	/**
 	 * A list of CAPI tags that is used to filter out articles from the section.

--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -3,7 +3,11 @@ import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { s3, secretsManager } from './aws';
 import { bucketName, capiSecretLocation } from './constants';
 
-export const putDataToS3 = async (dataToStore: string, date: Date) => {
+export const putDataToS3 = async (
+	dataToStore: string,
+	date: Date,
+	editionId: string,
+) => {
 	const objectLocation = [
 		date.getFullYear(),
 		(date.getMonth() + 1).toString().padStart(2, '0'),
@@ -13,7 +17,7 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 
 	const params = {
 		Bucket: bucketName,
-		Key: ['data', objectLocation].join('/'),
+		Key: ['data', editionId, objectLocation].join('/'),
 		Body: dataToStore,
 		ContentType: 'application/json',
 	};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds an extra `editionId` field to the `PressReaderEditionConfig` type. It also uses the value of this field as part of the key when saving outputs to S3.

The intention behind this is to make it easier to introduce and manage multiple editions within a single S3 bucket. (Which I'm currently assuming we will want to do?)
