### PR TITLE
Refactor collectionIndexes to start at 0

### DIFF
--- a/packages/pressreader/src/config.ts
+++ b/packages/pressreader/src/config.ts
@@ -7,7 +7,7 @@ export const editionConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [1],
+					collectionIndexes: [0],
 					collectionNames: ['Headlines'],
 					sectionContentURL:
 						'http://api.nextgen.guardianapps.co.uk/au/lite.json',
@@ -20,7 +20,7 @@ export const editionConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 14,
 			frontSources: [
 				{
-					collectionIndexes: [1],
+					collectionIndexes: [0],
 					collectionNames: ['Australia news'],
 					sectionContentURL:
 						'http://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
@@ -98,7 +98,7 @@ export const editionConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 6,
 			frontSources: [
 				{
-					collectionIndexes: [1, 3, 2, 4, 6],
+					collectionIndexes: [0, 2, 1, 3, 5],
 					collectionNames: [],
 					sectionContentURL:
 						'http://api.nextgen.guardianapps.co.uk/au/business/lite.json',

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -26,8 +26,11 @@ export interface SectionConfig {
 export interface FrontSource {
 	/**
 	 * The index of the collection as it occurs in the pressed front json.
-	 * (nb. not all collections are displayed on the web version of the front page,
-	 * so indexes should not be inferred from the position of a collection on the web)
+	 *
+	 * Notes:
+	 * - not all collections are displayed on the web version of the front page,
+	 *  so indexes should not be inferred from the position of a collection on the web
+	 * - collection indexes start at 0, rather than 1,
 	 */
 	collectionIndexes: number[];
 	/**


### PR DESCRIPTION
I believe that this will be the most intuitive way of indexing collections for developers, and fits the defaults of JavaScript.

Determining the indexes for a collection requires looking at the JSON representation of a front page, so for the time being it seems reasonable to assume that people editing this config will be familiar with the zero-index convention.

The actual code shouldn't need to change, because I'd been working on the assumption that the indexes start at 0. So this config change should also bring the output closer into line with the existing script.