### PR TITLE
Update infrastructure setup to create lambda per config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Build
         run: |
@@ -51,7 +51,7 @@ jobs:
               - packages/pressreader/dist/pressreader.zip
             pressreader-AUS:
               - packages/pressreader/dist/pressreader.zip
-            # pressreader-US-old:
-            #   - packages/pressreader/dist/pressreader.zip
-            # pressreader-AUS-old:
-            #   - packages/pressreader/dist/pressreader.zip
+            pressreader-US-old:
+              - packages/pressreader/dist/pressreader.zip
+            pressreader-AUS-old:
+              - packages/pressreader/dist/pressreader.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,7 @@ jobs:
           contentDirectories: |
             cdk.out:
               - packages/cdk/cdk.out
-            pressreader:
+            pressreader-US:
+              - packages/pressreader/dist/pressreader.zip
+            pressreader-AUS:
               - packages/pressreader/dist/pressreader.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,7 @@ jobs:
               - packages/pressreader/dist/pressreader.zip
             pressreader-AUS:
               - packages/pressreader/dist/pressreader.zip
+            # pressreader-US-old:
+            #   - packages/pressreader/dist/pressreader.zip
+            # pressreader-AUS-old:
+            #   - packages/pressreader/dist/pressreader.zip

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -18,7 +18,6 @@ new PressReader(app, 'PressReader-INFRA', {
 			editionKey: 'US',
 			s3PrefixPath: ['data', 'US'],
 		},
-		/*
 		{
 			editionKey: 'AUS',
 			s3PrefixPath: ['testing'],
@@ -29,6 +28,5 @@ new PressReader(app, 'PressReader-INFRA', {
 			s3PrefixPath: ['testing'],
 			bucketName: 'press-reader-us-configs',
 		},
-		*/
 	],
 });

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -18,5 +18,17 @@ new PressReader(app, 'PressReader-INFRA', {
 			editionKey: 'US',
 			s3PrefixPath: ['data', 'US'],
 		},
+		/*
+		{
+			editionKey: 'AUS',
+			s3PrefixPath: ['data', 'AUS'],
+			bucketName: 'press-reader-aus-configs',
+		},
+		{
+			editionKey: 'US',
+			s3PrefixPath: ['data', 'US'],
+			bucketName: 'press-reader-us-configs',
+		},
+		*/
 	],
 });

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -3,23 +3,20 @@ import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/ro
 import { PressReader } from '../lib/pressreader';
 
 const app = new GuRootExperimental();
-const ausEditionKey = 'AUS';
 
-new PressReader(app, 'PressReaderAus-INFRA', {
+new PressReader(app, 'PressReader-INFRA', {
 	env: { region: 'eu-west-1' },
 	app: 'pressreader',
 	stack: 'print-production',
 	stage: 'INFRA',
-	editionKey: ausEditionKey,
-	prefixPath: ['data', ausEditionKey],
-});
-
-new PressReader(app, 'PressReaderAusOld-INFRA', {
-	env: { region: 'eu-west-1' },
-	app: 'pressreader',
-	stack: 'print-production',
-	stage: 'INFRA',
-	editionKey: ausEditionKey,
-	bucketName: 'press-reader-aus-configs',
-	prefixPath: ['testing'],
+	lambdaConfigs: [
+		{
+			editionKey: 'AUS',
+			s3PrefixPath: ['data', 'AUS'],
+		},
+		{
+			editionKey: 'US',
+			s3PrefixPath: ['data', 'US'],
+		},
+	],
 });

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -21,12 +21,12 @@ new PressReader(app, 'PressReader-INFRA', {
 		/*
 		{
 			editionKey: 'AUS',
-			s3PrefixPath: ['data', 'AUS'],
+			s3PrefixPath: ['testing'],
 			bucketName: 'press-reader-aus-configs',
 		},
 		{
 			editionKey: 'US',
-			s3PrefixPath: ['data', 'US'],
+			s3PrefixPath: ['testing'],
 			bucketName: 'press-reader-us-configs',
 		},
 		*/

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -3,10 +3,23 @@ import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/ro
 import { PressReader } from '../lib/pressreader';
 
 const app = new GuRootExperimental();
+const ausEditionKey = 'AUS';
 
-new PressReader(app, 'PressReader-INFRA', {
+new PressReader(app, 'PressReaderAus-INFRA', {
 	env: { region: 'eu-west-1' },
 	app: 'pressreader',
 	stack: 'print-production',
 	stage: 'INFRA',
+	editionKey: ausEditionKey,
+	prefixPath: ['data', ausEditionKey],
+});
+
+new PressReader(app, 'PressReaderAusOld-INFRA', {
+	env: { region: 'eu-west-1' },
+	app: 'pressreader',
+	stack: 'print-production',
+	stage: 'INFRA',
+	editionKey: ausEditionKey,
+	bucketName: 'press-reader-aus-configs',
+	prefixPath: ['testing'],
 });

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -102,7 +102,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                         "Arn",
                       ],
                     },
-                    "/data/*",
+                    "/data/AUS/*",
                   ],
                 ],
               },
@@ -206,6 +206,101 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::ApiGateway::RestApi",
+    },
+    "PressReaderAPIAUS34ADC021": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "PressReaderAPI27D6A559",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "AUS",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIAUSkeyA35B3B3C": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "PressReaderAPIAUS34ADC021",
+        },
+        "PathPart": "{key}",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIAUSkeyGET6D653F26": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayS3AssumeRoleC6FF4BBF",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "GET",
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.path.key": "method.request.path.key",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":s3:path/",
+                {
+                  "Ref": "PressreaderDataBucketPressreader48E10950",
+                },
+                "/data/AUS/{key}.json",
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Length": true,
+              "method.response.header.Content-Type": true,
+            },
+            "StatusCode": "200",
+          },
+        ],
+        "RequestParameters": {
+          "method.request.header.Content-Type": true,
+          "method.request.path.key": true,
+        },
+        "ResourceId": {
+          "Ref": "PressReaderAPIAUSkeyA35B3B3C",
+        },
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
     },
     "PressReaderAPIAccount0348D010": {
       "DeletionPolicy": "Retain",
@@ -320,11 +415,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
-    "PressReaderAPIDeployment76372679e3895ad93ebdd14299f5c92e17122e30": {
+    "PressReaderAPIDeployment76372679c4b58fc57f95325d6c2d3711c3bb43df": {
       "DependsOn": [
-        "PressReaderAPIdatakeyGET902D4076",
-        "PressReaderAPIdatakey9D39D3B4",
-        "PressReaderAPIdata6C16C1E3",
+        "PressReaderAPIAUSkeyGET6D653F26",
+        "PressReaderAPIAUSkeyA35B3B3C",
+        "PressReaderAPIAUS34ADC021",
       ],
       "Properties": {
         "Description": "Serves data to Press Reader from an S3 bucket.",
@@ -340,7 +435,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment76372679e3895ad93ebdd14299f5c92e17122e30",
+          "Ref": "PressReaderAPIDeployment76372679c4b58fc57f95325d6c2d3711c3bb43df",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -451,105 +546,10 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::ApiKey",
     },
-    "PressReaderAPIdata6C16C1E3": {
-      "Properties": {
-        "ParentId": {
-          "Fn::GetAtt": [
-            "PressReaderAPI27D6A559",
-            "RootResourceId",
-          ],
-        },
-        "PathPart": "data",
-        "RestApiId": {
-          "Ref": "PressReaderAPI27D6A559",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "PressReaderAPIdatakey9D39D3B4": {
-      "Properties": {
-        "ParentId": {
-          "Ref": "PressReaderAPIdata6C16C1E3",
-        },
-        "PathPart": "{key}",
-        "RestApiId": {
-          "Ref": "PressReaderAPI27D6A559",
-        },
-      },
-      "Type": "AWS::ApiGateway::Resource",
-    },
-    "PressReaderAPIdatakeyGET902D4076": {
-      "Properties": {
-        "ApiKeyRequired": true,
-        "AuthorizationType": "NONE",
-        "HttpMethod": "GET",
-        "Integration": {
-          "Credentials": {
-            "Fn::GetAtt": [
-              "ApiGatewayS3AssumeRoleC6FF4BBF",
-              "Arn",
-            ],
-          },
-          "IntegrationHttpMethod": "GET",
-          "IntegrationResponses": [
-            {
-              "ResponseParameters": {
-                "method.response.header.Content-Type": "integration.response.header.Content-Type",
-              },
-              "StatusCode": "200",
-            },
-          ],
-          "RequestParameters": {
-            "integration.request.path.key": "method.request.path.key",
-          },
-          "Type": "AWS",
-          "Uri": {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":apigateway:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":s3:path/",
-                {
-                  "Ref": "PressreaderDataBucketPressreader48E10950",
-                },
-                "/data/{key}.json",
-              ],
-            ],
-          },
-        },
-        "MethodResponses": [
-          {
-            "ResponseParameters": {
-              "method.response.header.Content-Length": true,
-              "method.response.header.Content-Type": true,
-            },
-            "StatusCode": "200",
-          },
-        ],
-        "RequestParameters": {
-          "method.request.header.Content-Type": true,
-          "method.request.path.key": true,
-        },
-        "ResourceId": {
-          "Ref": "PressReaderAPIdatakey9D39D3B4",
-        },
-        "RestApiId": {
-          "Ref": "PressReaderAPI27D6A559",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
     "PressreaderDataBucketPressreader48E10950": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "BucketName": "gu-pressreader-data-aus",
+        "BucketName": "gu-pressreader-data-test",
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -599,43 +599,103 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "pressreaderemailalarmtopic5E019B49": {
+    "pressreaderAUSlambdaErrorPercentageAlarmForLambdaC0AE02E7": {
       "Properties": {
-        "Tags": [
+        "ActionsEnabled": true,
+        "AlarmActions": [
           {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/pressreader",
-          },
-          {
-            "Key": "Stack",
-            "Value": "print-production",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
           },
         ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderAUSlambdaFD0F9524",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSlambdaFD0F9524",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSlambdaFD0F9524",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
       },
-      "Type": "AWS::SNS::Topic",
+      "Type": "AWS::CloudWatch::Alarm",
     },
-    "pressreaderemailalarmtopicnewsroomresiliencealertsguardiancoukC7FA91A6": {
-      "Properties": {
-        "Endpoint": "newsroom.resilience+alerts@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "pressreaderemailalarmtopic5E019B49",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "pressreaderlambdaB481BEF0": {
+    "pressreaderAUSlambdaFD0F9524": {
       "DependsOn": [
-        "pressreaderlambdaServiceRoleDefaultPolicy7471EACC",
-        "pressreaderlambdaServiceRole68181491",
+        "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D",
+        "pressreaderAUSlambdaServiceRole14934F9E",
       ],
       "Properties": {
         "Code": {
@@ -704,7 +764,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "AUS",
-            "PREFIX_PATH": "data",
+            "PREFIX_PATH": "data/AUS",
             "STACK": "print-production",
             "STAGE": "TEST",
           },
@@ -713,7 +773,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "pressreaderlambdaServiceRole68181491",
+            "pressreaderAUSlambdaServiceRole14934F9E",
             "Arn",
           ],
         },
@@ -744,100 +804,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "pressreaderlambdaErrorPercentageAlarmForLambda62A3B054": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "pressreaderlambdaB481BEF0",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderlambdaB481BEF0",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderlambdaB481BEF0",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "pressreaderlambdaServiceRole68181491": {
+    "pressreaderAUSlambdaServiceRole14934F9E": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -890,7 +857,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "pressreaderlambdaServiceRoleDefaultPolicy7471EACC": {
+    "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -998,7 +965,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                         "Arn",
                       ],
                     },
-                    "/data/*",
+                    "/data/AUS/*",
                   ],
                 ],
               },
@@ -1006,16 +973,16 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "pressreaderlambdaServiceRoleDefaultPolicy7471EACC",
+        "PolicyName": "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D",
         "Roles": [
           {
-            "Ref": "pressreaderlambdaServiceRole68181491",
+            "Ref": "pressreaderAUSlambdaServiceRole14934F9E",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pressreaderlambdapressreaderlambdarate1hour050777DAB": {
+    "pressreaderAUSlambdapressreaderAUSlambdarate1hour045FDCC1D": {
       "Properties": {
         "ScheduleExpression": "rate(1 hour)",
         "State": "ENABLED",
@@ -1023,7 +990,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           {
             "Arn": {
               "Fn::GetAtt": [
-                "pressreaderlambdaB481BEF0",
+                "pressreaderAUSlambdaFD0F9524",
                 "Arn",
               ],
             },
@@ -1033,24 +1000,57 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderlambdapressreaderlambdarate1hour0AllowEventRulePressReaderpressreaderlambda88EE711E7334912E": {
+    "pressreaderAUSlambdapressreaderAUSlambdarate1hour0AllowEventRulePressReaderpressreaderAUSlambda3E14C4F831DEEB95": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "pressreaderlambdaB481BEF0",
+            "pressreaderAUSlambdaFD0F9524",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderlambdapressreaderlambdarate1hour050777DAB",
+            "pressreaderAUSlambdapressreaderAUSlambdarate1hour045FDCC1D",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderemailalarmtopic5E019B49": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "pressreaderemailalarmtopicnewsroomresiliencealertsguardiancoukC7FA91A6": {
+      "Properties": {
+        "Endpoint": "newsroom.resilience+alerts@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "pressreaderemailalarmtopic5E019B49",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
   },
 }

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -549,7 +549,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
     "PressreaderDataBucketPressreader48E10950": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "BucketName": "gu-pressreader-data-test",
+        "BucketName": "gu-pressreader-data-aus",
         "PublicAccessBlockConfiguration": {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -703,6 +703,8 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ],
               ],
             },
+            "EDITION_KEY": "AUS",
+            "PREFIX_PATH": "data",
             "STACK": "print-production",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -861,7 +861,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "AlarmName": "pressreader-AUS-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 120,
         "Metrics": [
@@ -1242,7 +1242,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "AlarmName": "pressreader-AUS-old-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 120,
         "Metrics": [
@@ -1697,7 +1697,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "AlarmName": "pressreader-US-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 120,
         "Metrics": [
@@ -1968,7 +1968,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "AlarmName": "pressreader-US-old-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
         "EvaluationPeriods": 120,
         "Metrics": [

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -10,6 +10,12 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -103,6 +109,24 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                       ],
                     },
                     "/data/AUS/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "PressreaderDataBucketPressreader48E10950",
+                        "Arn",
+                      ],
+                    },
+                    "/data/US/*",
                   ],
                 ],
               },
@@ -415,11 +439,14 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::BasePathMapping",
     },
-    "PressReaderAPIDeployment76372679c4b58fc57f95325d6c2d3711c3bb43df": {
+    "PressReaderAPIDeployment76372679c63aecad3660742617189f6d49cb6d19": {
       "DependsOn": [
         "PressReaderAPIAUSkeyGET6D653F26",
         "PressReaderAPIAUSkeyA35B3B3C",
         "PressReaderAPIAUS34ADC021",
+        "PressReaderAPIUSkeyGET413633C4",
+        "PressReaderAPIUSkey4F426D58",
+        "PressReaderAPIUSED3F75B1",
       ],
       "Properties": {
         "Description": "Serves data to Press Reader from an S3 bucket.",
@@ -435,7 +462,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "PressReaderAPIDeployment76372679c4b58fc57f95325d6c2d3711c3bb43df",
+          "Ref": "PressReaderAPIDeployment76372679c63aecad3660742617189f6d49cb6d19",
         },
         "RestApiId": {
           "Ref": "PressReaderAPI27D6A559",
@@ -546,6 +573,101 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::ApiGateway::ApiKey",
     },
+    "PressReaderAPIUSED3F75B1": {
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "PressReaderAPI27D6A559",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "US",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIUSkey4F426D58": {
+      "Properties": {
+        "ParentId": {
+          "Ref": "PressReaderAPIUSED3F75B1",
+        },
+        "PathPart": "{key}",
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "PressReaderAPIUSkeyGET413633C4": {
+      "Properties": {
+        "ApiKeyRequired": true,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "GET",
+        "Integration": {
+          "Credentials": {
+            "Fn::GetAtt": [
+              "ApiGatewayS3AssumeRoleC6FF4BBF",
+              "Arn",
+            ],
+          },
+          "IntegrationHttpMethod": "GET",
+          "IntegrationResponses": [
+            {
+              "ResponseParameters": {
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+              },
+              "StatusCode": "200",
+            },
+          ],
+          "RequestParameters": {
+            "integration.request.path.key": "method.request.path.key",
+          },
+          "Type": "AWS",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":apigateway:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":s3:path/",
+                {
+                  "Ref": "PressreaderDataBucketPressreader48E10950",
+                },
+                "/data/US/{key}.json",
+              ],
+            ],
+          },
+        },
+        "MethodResponses": [
+          {
+            "ResponseParameters": {
+              "method.response.header.Content-Length": true,
+              "method.response.header.Content-Type": true,
+            },
+            "StatusCode": "200",
+          },
+        ],
+        "RequestParameters": {
+          "method.request.header.Content-Type": true,
+          "method.request.path.key": true,
+        },
+        "ResourceId": {
+          "Ref": "PressReaderAPIUSkey4F426D58",
+        },
+        "RestApiId": {
+          "Ref": "PressReaderAPI27D6A559",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
     "PressreaderDataBucketPressreader48E10950": {
       "DeletionPolicy": "Retain",
       "Properties": {
@@ -599,114 +721,21 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
-    "pressreaderAUSlambdaErrorPercentageAlarmForLambdaC0AE02E7": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-TEST-ErrorAlarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "pressreaderAUSlambdaFD0F9524",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUSlambdaFD0F9524",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUSlambdaFD0F9524",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "pressreaderAUSlambdaFD0F9524": {
+    "pressreaderAUS6886FE30": {
       "DependsOn": [
-        "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D",
-        "pressreaderAUSlambdaServiceRole14934F9E",
+        "pressreaderAUSServiceRoleDefaultPolicy7524F0C8",
+        "pressreaderAUSServiceRole2C141000",
       ],
       "Properties": {
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "print-production/TEST/pressreader/pressreader.zip",
+          "S3Key": "print-production/TEST/pressreader-AUS/pressreader.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "pressreader",
+            "APP": "pressreader-AUS",
             "BUCKET_NAME": {
               "Ref": "PressreaderDataBucketPressreader48E10950",
             },
@@ -773,7 +802,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "pressreaderAUSlambdaServiceRole14934F9E",
+            "pressreaderAUSServiceRole2C141000",
             "Arn",
           ],
         },
@@ -781,7 +810,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Tags": [
           {
             "Key": "App",
-            "Value": "pressreader",
+            "Value": "pressreader-AUS",
           },
           {
             "Key": "gu:cdk:version",
@@ -804,7 +833,100 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "pressreaderAUSlambdaServiceRole14934F9E": {
+    "pressreaderAUSErrorPercentageAlarmForLambda163DFFB6": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderAUS6886FE30",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUS6886FE30",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUS6886FE30",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "pressreaderAUSServiceRole2C141000": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -835,7 +957,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Tags": [
           {
             "Key": "App",
-            "Value": "pressreader",
+            "Value": "pressreader-AUS",
           },
           {
             "Key": "gu:cdk:version",
@@ -857,7 +979,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D": {
+    "pressreaderAUSServiceRoleDefaultPolicy7524F0C8": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -896,7 +1018,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/print-production/TEST/pressreader/pressreader.zip",
+                      "/print-production/TEST/pressreader-AUS/pressreader.zip",
                     ],
                   ],
                 },
@@ -917,7 +1039,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/print-production/pressreader",
+                    ":parameter/TEST/print-production/pressreader-AUS",
                   ],
                 ],
               },
@@ -940,7 +1062,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/print-production/pressreader/*",
+                    ":parameter/TEST/print-production/pressreader-AUS/*",
                   ],
                 ],
               },
@@ -973,16 +1095,395 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "pressreaderAUSlambdaServiceRoleDefaultPolicy024D5A8D",
+        "PolicyName": "pressreaderAUSServiceRoleDefaultPolicy7524F0C8",
         "Roles": [
           {
-            "Ref": "pressreaderAUSlambdaServiceRole14934F9E",
+            "Ref": "pressreaderAUSServiceRole2C141000",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pressreaderAUSlambdapressreaderAUSlambdarate1hour045FDCC1D": {
+    "pressreaderAUSold903A9CEE": {
+      "DependsOn": [
+        "pressreaderAUSoldServiceRoleDefaultPolicy820D82A8",
+        "pressreaderAUSoldServiceRoleF5EDA110",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "print-production/TEST/pressreader-AUS-old/pressreader.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "pressreader-AUS-old",
+            "BUCKET_NAME": "press-reader-aus-configs",
+            "CAPI_SECRET_LOCATION": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "EDITION_KEY": "AUS",
+            "PREFIX_PATH": "",
+            "STACK": "print-production",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "pressreaderAUSoldServiceRoleF5EDA110",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-AUS-old",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderAUSoldErrorPercentageAlarmForLambdaACAD7657": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderAUSold903A9CEE",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSold903A9CEE",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSold903A9CEE",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "pressreaderAUSoldServiceRoleDefaultPolicy820D82A8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/print-production/TEST/pressreader-AUS-old/pressreader.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-AUS-old",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-AUS-old/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiTokenSecret1D3F4E33",
+              },
+            },
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::press-reader-aus-configs/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pressreaderAUSoldServiceRoleDefaultPolicy820D82A8",
+        "Roles": [
+          {
+            "Ref": "pressreaderAUSoldServiceRoleF5EDA110",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderAUSoldServiceRoleF5EDA110": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-AUS-old",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pressreaderAUSoldpressreaderAUSoldrate1hour00BA33D45": {
       "Properties": {
         "ScheduleExpression": "rate(1 hour)",
         "State": "ENABLED",
@@ -990,7 +1491,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           {
             "Arn": {
               "Fn::GetAtt": [
-                "pressreaderAUSlambdaFD0F9524",
+                "pressreaderAUSold903A9CEE",
                 "Arn",
               ],
             },
@@ -1000,24 +1501,897 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderAUSlambdapressreaderAUSlambdarate1hour0AllowEventRulePressReaderpressreaderAUSlambda3E14C4F831DEEB95": {
+    "pressreaderAUSoldpressreaderAUSoldrate1hour0AllowEventRulePressReaderpressreaderAUSoldCA113CF63CD0929A": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Fn::GetAtt": [
-            "pressreaderAUSlambdaFD0F9524",
+            "pressreaderAUSold903A9CEE",
             "Arn",
           ],
         },
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderAUSlambdapressreaderAUSlambdarate1hour045FDCC1D",
+            "pressreaderAUSoldpressreaderAUSoldrate1hour00BA33D45",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderAUSpressreaderAUSrate1hour0AllowEventRulePressReaderpressreaderAUSF42A35B90A948F31": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderAUS6886FE30",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "pressreaderAUSpressreaderAUSrate1hour0FE217D2C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderAUSpressreaderAUSrate1hour0FE217D2C": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 hour)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "pressreaderAUS6886FE30",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "pressreaderUS45258E18": {
+      "DependsOn": [
+        "pressreaderUSServiceRoleDefaultPolicyE1F8503D",
+        "pressreaderUSServiceRoleB97C448A",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "print-production/TEST/pressreader-US/pressreader.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "pressreader-US",
+            "BUCKET_NAME": {
+              "Ref": "PressreaderDataBucketPressreader48E10950",
+            },
+            "CAPI_SECRET_LOCATION": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "EDITION_KEY": "US",
+            "PREFIX_PATH": "data/US",
+            "STACK": "print-production",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "pressreaderUSServiceRoleB97C448A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-US",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderUSErrorPercentageAlarmForLambda42ECEB9A": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderUS45258E18",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUS45258E18",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUS45258E18",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "pressreaderUSServiceRoleB97C448A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-US",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pressreaderUSServiceRoleDefaultPolicyE1F8503D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/print-production/TEST/pressreader-US/pressreader.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-US",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-US/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiTokenSecret1D3F4E33",
+              },
+            },
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Fn::GetAtt": [
+                        "PressreaderDataBucketPressreader48E10950",
+                        "Arn",
+                      ],
+                    },
+                    "/data/US/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pressreaderUSServiceRoleDefaultPolicyE1F8503D",
+        "Roles": [
+          {
+            "Ref": "pressreaderUSServiceRoleB97C448A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderUSoldErrorPercentageAlarmForLambdaF82C074F": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-TEST-ErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 120,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderUSoldF30522C8",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUSoldF30522C8",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUSoldF30522C8",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "pressreaderUSoldF30522C8": {
+      "DependsOn": [
+        "pressreaderUSoldServiceRoleDefaultPolicyE849A76E",
+        "pressreaderUSoldServiceRole06560AC9",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "print-production/TEST/pressreader-US-old/pressreader.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "pressreader-US-old",
+            "BUCKET_NAME": "press-reader-us-configs",
+            "CAPI_SECRET_LOCATION": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "EDITION_KEY": "US",
+            "PREFIX_PATH": "",
+            "STACK": "print-production",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "pressreaderUSoldServiceRole06560AC9",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-US-old",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "pressreaderUSoldServiceRole06560AC9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pressreader-US-old",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "pressreaderUSoldServiceRoleDefaultPolicyE849A76E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/print-production/TEST/pressreader-US-old/pressreader.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-US-old",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/print-production/pressreader-US-old/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CapiTokenSecret1D3F4E33",
+              },
+            },
+            {
+              "Action": "s3:PutObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::press-reader-us-configs/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "pressreaderUSoldServiceRoleDefaultPolicyE849A76E",
+        "Roles": [
+          {
+            "Ref": "pressreaderUSoldServiceRole06560AC9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderUSoldpressreaderUSoldrate1hour04CD2FA55": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 hour)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "pressreaderUSoldF30522C8",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "pressreaderUSoldpressreaderUSoldrate1hour0AllowEventRulePressReaderpressreaderUSoldA7BBDD877B3212F7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderUSoldF30522C8",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "pressreaderUSoldpressreaderUSoldrate1hour04CD2FA55",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderUSpressreaderUSrate1hour0AllowEventRulePressReaderpressreaderUS9932EDA5A4CFE4A7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "pressreaderUS45258E18",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "pressreaderUSpressreaderUSrate1hour0DCE77B96",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "pressreaderUSpressreaderUSrate1hour0DCE77B96": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 hour)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "pressreaderUS45258E18",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "pressreaderemailalarmtopic5E019B49": {
       "Properties": {

--- a/packages/cdk/lib/pressreader.test.ts
+++ b/packages/cdk/lib/pressreader.test.ts
@@ -8,7 +8,20 @@ describe('The PressReader stack', () => {
 		const stack = new PressReader(app, 'PressReader', {
 			stack: 'print-production',
 			stage: 'TEST',
-			lambdaConfigs: [{ editionKey: 'AUS', s3PrefixPath: ['data', 'AUS'] }],
+			lambdaConfigs: [
+				{ editionKey: 'AUS', s3PrefixPath: ['data', 'AUS'] },
+				{ editionKey: 'US', s3PrefixPath: ['data', 'US'] },
+				{
+					editionKey: 'AUS',
+					s3PrefixPath: [],
+					bucketName: 'press-reader-aus-configs',
+				},
+				{
+					editionKey: 'US',
+					s3PrefixPath: [],
+					bucketName: 'press-reader-us-configs',
+				},
+			],
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/packages/cdk/lib/pressreader.test.ts
+++ b/packages/cdk/lib/pressreader.test.ts
@@ -8,8 +8,7 @@ describe('The PressReader stack', () => {
 		const stack = new PressReader(app, 'PressReader', {
 			stack: 'print-production',
 			stage: 'TEST',
-			editionKey: 'AUS',
-			prefixPath: ['data'],
+			lambdaConfigs: [{ editionKey: 'AUS', s3PrefixPath: ['data', 'AUS'] }],
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/packages/cdk/lib/pressreader.test.ts
+++ b/packages/cdk/lib/pressreader.test.ts
@@ -8,6 +8,8 @@ describe('The PressReader stack', () => {
 		const stack = new PressReader(app, 'PressReader', {
 			stack: 'print-production',
 			stage: 'TEST',
+			editionKey: 'AUS',
+			prefixPath: ['data'],
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -207,6 +207,13 @@ export class PressReader extends GuStack {
 				this,
 				`${appName}-${lambdaSuffix}`,
 				{
+					// The riff-raff.yaml auto-generation incorporated
+					// by using GuRootExperimental, and outputting to
+					// cdk/cdk.out/riff-raff.yaml when the synth task is
+					// run uses this value to identify what to deploy.
+					//
+					// This value must match one of the contentDirectories
+					// identified in .github/workflows/ci.yml
 					app: `${appName}-${lambdaSuffix}`,
 					runtime: Runtime.NODEJS_18_X,
 					memorySize: 512,

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -23,9 +23,11 @@ import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 type EditionKey = 'AUS' | 'US';
 
 export interface PressReaderProps extends GuStackProps {
-	bucketName?: string;
-	editionKey: EditionKey;
-	prefixPath: string[];
+	lambdaConfigs: Array<{
+		bucketName?: string;
+		editionKey: EditionKey;
+		s3PrefixPath: string[];
+	}>;
 }
 
 export class PressReader extends GuStack {
@@ -33,16 +35,16 @@ export class PressReader extends GuStack {
 		super(scope, id, props);
 		const appName = 'pressreader';
 		const domainName = 'pressreader.gutools.co.uk';
-		const { bucketName, editionKey, prefixPath } = props;
 
 		// S3 Bucket
-		const dataBucket =
-			bucketName === undefined
-				? new GuS3Bucket(this, 'PressreaderDataBucket', {
-						app: appName,
-						bucketName: `gu-pressreader-data-${editionKey.toLowerCase()}`,
-				  })
-				: GuS3Bucket.fromBucketName(this, 'dataBucket', bucketName);
+		const dataBucket = new GuS3Bucket(this, 'PressreaderDataBucket', {
+			app: appName,
+			bucketName: `gu-pressreader-data-${this.stage.toLowerCase()}`,
+		});
+
+		const lambdasUsingDataBucket = props.lambdaConfigs.filter(
+			(config) => config.bucketName === undefined,
+		);
 
 		// ACM Certificate
 		const certificate = new GuCertificate(this, {
@@ -65,53 +67,61 @@ export class PressReader extends GuStack {
 			roleName: 'APIGatewayS3IntegrationRole',
 		});
 
-		executeRole.addToPolicy(
-			new PolicyStatement({
-				resources: [[dataBucket.bucketArn, ...prefixPath, '*'].join('/')],
-				actions: ['s3:GetObject'],
-			}),
-		);
+		lambdasUsingDataBucket.forEach((lambdaConfig) => {
+			executeRole.addToPolicy(
+				new PolicyStatement({
+					resources: [
+						[dataBucket.bucketArn, ...lambdaConfig.s3PrefixPath, '*'].join('/'),
+					],
+					actions: ['s3:GetObject'],
+				}),
+			);
 
-		const s3Integration = new AwsIntegration({
-			service: 's3',
-			integrationHttpMethod: 'GET',
-			path: [dataBucket.bucketName, ...prefixPath, '{key}.json'].join('/'),
-			options: {
-				credentialsRole: executeRole,
-				integrationResponses: [
-					{
-						statusCode: '200',
-						responseParameters: {
-							'method.response.header.Content-Type':
-								'integration.response.header.Content-Type',
+			const s3Integration = new AwsIntegration({
+				service: 's3',
+				integrationHttpMethod: 'GET',
+				path: [
+					dataBucket.bucketName,
+					...lambdaConfig.s3PrefixPath,
+					'{key}.json',
+				].join('/'),
+				options: {
+					credentialsRole: executeRole,
+					integrationResponses: [
+						{
+							statusCode: '200',
+							responseParameters: {
+								'method.response.header.Content-Type':
+									'integration.response.header.Content-Type',
+							},
 						},
+					],
+					requestParameters: {
+						'integration.request.path.key': 'method.request.path.key',
 					},
-				],
-				requestParameters: {
-					'integration.request.path.key': 'method.request.path.key',
 				},
-			},
-		});
-
-		apiGateway.root
-			.addResource('data')
-			.addResource('{key}')
-			.addMethod('GET', s3Integration, {
-				methodResponses: [
-					{
-						statusCode: '200',
-						responseParameters: {
-							'method.response.header.Content-Length': true,
-							'method.response.header.Content-Type': true,
-						},
-					},
-				],
-				requestParameters: {
-					'method.request.path.key': true,
-					'method.request.header.Content-Type': true,
-				},
-				apiKeyRequired: true,
 			});
+
+			apiGateway.root
+				.addResource(lambdaConfig.editionKey)
+				.addResource('{key}')
+				.addMethod('GET', s3Integration, {
+					methodResponses: [
+						{
+							statusCode: '200',
+							responseParameters: {
+								'method.response.header.Content-Length': true,
+								'method.response.header.Content-Type': true,
+							},
+						},
+					],
+					requestParameters: {
+						'method.request.path.key': true,
+						'method.request.header.Content-Type': true,
+					},
+					apiKeyRequired: true,
+				});
+		});
 
 		// create usage plan
 		const usagePlan = apiGateway.addUsagePlan('PressReaderAPIUsagePlan', {
@@ -171,30 +181,46 @@ export class PressReader extends GuStack {
 			resources: [capiSecret.secretArn],
 		});
 
-		const s3PutPolicyStatement = new PolicyStatement({
-			effect: Effect.ALLOW,
-			actions: ['s3:PutObject'],
-			resources: [[dataBucket.bucketArn, ...prefixPath, '*'].join('/')],
-		});
+		props.lambdaConfigs.forEach((config) => {
+			const [lambdaBucket, lambdaSuffix] =
+				config.bucketName === undefined
+					? [dataBucket, '']
+					: [
+							GuS3Bucket.fromBucketName(this, 'dataBucket', config.bucketName),
+							'-old',
+					  ];
 
-		const scheduledLambda = new GuScheduledLambda(this, `${appName}-lambda`, {
-			app: appName,
-			runtime: Runtime.NODEJS_18_X,
-			memorySize: 512,
-			handler: 'handler.main',
-			environment: {
-				BUCKET_NAME: dataBucket.bucketName,
-				CAPI_SECRET_LOCATION: capiSecret.secretName,
-				EDITION_KEY: editionKey,
-				PREFIX_PATH: prefixPath.join('/'),
-			},
-			fileName: `pressreader.zip`,
-			monitoringConfiguration,
-			rules: [{ schedule: Schedule.rate(Duration.hours(1)) }],
-			timeout: Duration.seconds(300),
-		});
+			const s3PutPolicyStatement = new PolicyStatement({
+				effect: Effect.ALLOW,
+				actions: ['s3:PutObject'],
+				resources: [
+					[lambdaBucket.bucketArn, ...config.s3PrefixPath, '*'].join('/'),
+				],
+			});
 
-		scheduledLambda.addToRolePolicy(capiSecretGetPolicyStatement);
-		scheduledLambda.addToRolePolicy(s3PutPolicyStatement);
+			const scheduledLambda = new GuScheduledLambda(
+				this,
+				`${appName}-${config.editionKey}-lambda${lambdaSuffix}`,
+				{
+					app: appName,
+					runtime: Runtime.NODEJS_18_X,
+					memorySize: 512,
+					handler: 'handler.main',
+					environment: {
+						BUCKET_NAME: lambdaBucket.bucketName,
+						CAPI_SECRET_LOCATION: capiSecret.secretName,
+						EDITION_KEY: config.editionKey,
+						PREFIX_PATH: config.s3PrefixPath.join('/'),
+					},
+					fileName: `pressreader.zip`,
+					monitoringConfiguration,
+					rules: [{ schedule: Schedule.rate(Duration.hours(1)) }],
+					timeout: Duration.seconds(300),
+				},
+			);
+
+			scheduledLambda.addToRolePolicy(capiSecretGetPolicyStatement);
+			scheduledLambda.addToRolePolicy(s3PutPolicyStatement);
+		});
 	}
 }

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -164,16 +164,6 @@ export class PressReader extends GuStack {
 		const alertEmail = `newsroom.resilience+alerts@guardian.co.uk`;
 		alarmSnsTopic.addSubscription(new EmailSubscription(alertEmail));
 
-		// monitoring config
-		const monitoringConfiguration = {
-			alarmName: `${appName}-${this.stage}-ErrorAlarm`,
-			alarmDescription: `Triggers if there are errors from ${appName} on ${this.stage}`,
-			snsTopicName: alarmSnsTopic.topicName,
-			toleratedErrorPercentage: 1,
-			// Requires 2 failures in a row based on lambda scheduled to run once an hour
-			numberOfMinutesAboveThresholdBeforeAlarm: 120,
-		};
-
 		// scheduled lambda
 		const capiSecretGetPolicyStatement = new PolicyStatement({
 			effect: Effect.ALLOW,
@@ -195,6 +185,16 @@ export class PressReader extends GuStack {
 							`legacyDataBucket-${lambdaSuffix}`,
 							config.bucketName,
 					  );
+
+			// monitoring config
+			const monitoringConfiguration = {
+				alarmName: `${appName}-${lambdaSuffix}-${this.stage}-ErrorAlarm`,
+				alarmDescription: `Triggers if there are errors from ${appName} on ${this.stage}`,
+				snsTopicName: alarmSnsTopic.topicName,
+				toleratedErrorPercentage: 1,
+				// Requires 2 failures in a row based on lambda scheduled to run once an hour
+				numberOfMinutesAboveThresholdBeforeAlarm: 120,
+			};
 
 			const s3PutPolicyStatement = new PolicyStatement({
 				effect: Effect.ALLOW,

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -19,8 +19,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
-
-type EditionKey = 'AUS' | 'US';
+import type { EditionKey } from 'packages/shared-types';
 
 export interface PressReaderProps extends GuStackProps {
 	lambdaConfigs: Array<{

--- a/packages/pressreader/src/constants.ts
+++ b/packages/pressreader/src/constants.ts
@@ -1,5 +1,6 @@
 export const awsRegion = process.env.AWS_REGION ?? 'eu-west-1';
 export const bucketName = process.env.BUCKET_NAME ?? 'dev-pressreader';
+export const prefixPath = process.env.PREFIX_PATH ?? '';
 export const editionKey = process.env.EDITION_KEY;
 export const capiSecretLocation =
 	process.env.CAPI_SECRET_LOCATION ??

--- a/packages/pressreader/src/constants.ts
+++ b/packages/pressreader/src/constants.ts
@@ -1,5 +1,6 @@
 export const awsRegion = process.env.AWS_REGION ?? 'eu-west-1';
 export const bucketName = process.env.BUCKET_NAME ?? 'dev-pressreader';
+export const editionKey = process.env.EDITION_KEY;
 export const capiSecretLocation =
 	process.env.CAPI_SECRET_LOCATION ??
 	'/DEV/print-production/pressreader/capiToken';

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -1,6 +1,6 @@
-import type { PressReaderEditionConfig } from './types/PressReaderTypes';
+import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
 
-export const editionConfig: PressReaderEditionConfig = {
+export const ausConfig: PressReaderEditionConfig = {
 	sections: [
 		{
 			displayName: 'Headlines',

--- a/packages/pressreader/src/editionConfigs/index.ts
+++ b/packages/pressreader/src/editionConfigs/index.ts
@@ -1,7 +1,9 @@
 import type { EditionKey } from 'packages/shared-types';
 import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
 import { ausConfig } from './ausConfig';
+import { usConfig } from './usConfig';
 
 export const editionConfigs: Record<EditionKey, PressReaderEditionConfig> = {
 	AUS: ausConfig,
+	US: usConfig,
 };

--- a/packages/pressreader/src/editionConfigs/index.ts
+++ b/packages/pressreader/src/editionConfigs/index.ts
@@ -1,0 +1,7 @@
+import type { EditionKey } from 'packages/shared-types';
+import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
+import { ausConfig } from './ausConfig';
+
+export const editionConfigs: Record<EditionKey, PressReaderEditionConfig> = {
+	AUS: ausConfig,
+};

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -1,0 +1,25 @@
+import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
+
+export const usConfig: PressReaderEditionConfig = {
+	sections: [
+		{
+			displayName: 'Politics',
+			maximumArticleCount: 8,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['Australian politics'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+				},
+			],
+			capiSources: [
+				'search?tag=australia-news%2Faustralian-politics&order-by=newest',
+			],
+		},
+	],
+	bannedTags: [
+		'sport/series/talking-horses',
+		'science/series/alex-bellos-monday-puzzle',
+	],
+};

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -3,19 +3,328 @@ import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
 export const usConfig: PressReaderEditionConfig = {
 	sections: [
 		{
+			displayName: 'Headlines',
+			maximumArticleCount: 10,
+			frontSources: [
+				{
+					collectionIndexes: [0],
+					collectionNames: ['headlines'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'News',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['US news'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['across the country'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
 			displayName: 'Politics',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['headlines'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['US politics'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: [
+						'in depth',
+						'Trump administration',
+						'the resistance',
+						'policy',
+					],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'World News',
 			maximumArticleCount: 8,
 			frontSources: [
 				{
 					collectionIndexes: [],
-					collectionNames: ['Australian politics'],
+					collectionNames: ['world news'],
 					sectionContentURL:
-						'http://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+						'http://api.nextgen.guardianapps.co.uk/world/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['around the world'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['around the world'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/world/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Opinion',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['opinion', 'spotlight'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['columnists & contributors', 'opinion'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/commentisfree/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['opinion & analysis'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['opinion'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['opinion & analysis'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/world/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['explore'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['spotlight', 'you may have missed'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/commentisfree/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'The Long Read',
+			maximumArticleCount: 2,
+			frontSources: [],
+			capiSources: ['search?tag=news%2Fseries%2Fthe-long-read&order-by=newest'],
+		},
+		{
+			displayName: 'Finance',
+			maximumArticleCount: 8,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['US business'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['business ', 'in depth'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/business/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['sustainable business', 'featured series '],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/sustainable-business/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['around the world'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/business/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'The Guardian View',
+			maximumArticleCount: 2,
+			frontSources: [],
+			capiSources: [
+				'search?tag=tone%2Feditorials&production-office=uk&order-by=newest',
+				'search?tag=tone%2Feditorials&order-by=newest',
+			],
+		},
+		{
+			displayName: 'Arts',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['arts', 'talking points', 'people'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/culture/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['film', 'talking points', 'news'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/film/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['music', 'talking points', 'news'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/music/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Fashion',
+			maximumArticleCount: 8,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: [
+						'fashion',
+						'talking points',
+						'news',
+						'you may have missed',
+						'the shows',
+					],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/fashion/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Environment',
+			maximumArticleCount: 6,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: [
+						'environment',
+						'talking points',
+						'featured series',
+						'this land is your land',
+						'keystone XL pipeline',
+						'energy',
+					],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/environment/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Science',
+			maximumArticleCount: 6,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['science', 'blog network', 'news', 'key issues'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/science/lite.json',
 				},
 			],
 			capiSources: [
-				'search?tag=australia-news%2Faustralian-politics&order-by=newest',
+				'search?tag=science%2Fscience&production-office=us&order-by=newest',
+				'search?tag=science%2Fscience&order-by=newest',
 			],
+		},
+		{
+			displayName: 'Technology',
+			maximumArticleCount: 8,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['technology', 'in depth'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/technology/lite.json',
+				},
+			],
+			capiSources: [],
+		},
+		{
+			displayName: 'Sport',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['US sports'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['across the country', 'sports'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/sport/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['sports'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/lite.json',
+				},
+				{
+					collectionIndexes: [],
+					collectionNames: ['around the world'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/us/sport/lite.json',
+				},
+			],
+			capiSources: [
+				'search?tag=sport%2Fnfl&order-by=newest',
+				'search?tag=sport%2Fmlb&order-by=newest',
+				'search?tag=sport%2Fnba&order-by=newest',
+				'search?tag=sport%2Fnhl&order-by=newest',
+			],
+		},
+		{
+			displayName: 'Soccer',
+			maximumArticleCount: 12,
+			frontSources: [
+				{
+					collectionIndexes: [],
+					collectionNames: ['football'],
+					sectionContentURL:
+						'http://api.nextgen.guardianapps.co.uk/football/lite.json',
+				},
+			],
+			capiSources: ['search?tag=football%2Fmls&order-by=newest'],
 		},
 	],
 	bannedTags: [

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -11,6 +11,12 @@ export const main = async () => {
 	const capiToken = await getCapiToken();
 	console.log(`Got capiToken (length): ${capiToken.length}`);
 
+	if (!isEditionKey(editionKey)) {
+		throw new Error(`Edition key ${editionKey ?? 'undefined'} is not valid`);
+	}
+
+	const editionConfig = editionConfigs[editionKey];
+
 	// TODO: Remove this log when consumed
 	console.log(`Got editionConfig: ${JSON.stringify(editionConfig)}`);
 

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -1,6 +1,12 @@
-import { editionConfig } from './config';
+import type { EditionKey } from 'packages/shared-types';
+import { editionKey } from './constants';
+import { editionConfigs } from './editionConfigs';
 import { editionProcessor } from './processEdition';
 import { getCapiToken, putDataToS3 } from './util';
+
+function isEditionKey(key: string | undefined): key is EditionKey {
+	return !!key && ['AUS'].includes(key);
+}
 
 export const main = async () => {
 	console.log('Lambda handler called, processing request');

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -1,12 +1,8 @@
-import type { EditionKey } from 'packages/shared-types';
+import { isEditionKey } from 'packages/shared-types';
 import { editionKey } from './constants';
 import { editionConfigs } from './editionConfigs';
 import { editionProcessor } from './processEdition';
 import { getCapiToken, putDataToS3 } from './util';
-
-function isEditionKey(key: string | undefined): key is EditionKey {
-	return !!key && ['AUS'].includes(key);
-}
 
 export const main = async () => {
 	console.log('Lambda handler called, processing request');

--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -1,7 +1,7 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { s3, secretsManager } from './aws';
-import { bucketName, capiSecretLocation } from './constants';
+import { bucketName, capiSecretLocation, prefixPath } from './constants';
 
 export const putDataToS3 = async (dataToStore: string, date: Date) => {
 	const objectLocation = [
@@ -13,7 +13,7 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 
 	const params = {
 		Bucket: bucketName,
-		Key: ['data', objectLocation].join('/'),
+		Key: [prefixPath, objectLocation].join('/'),
 		Body: dataToStore,
 		ContentType: 'application/json',
 	};

--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -11,16 +11,16 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 		'.json',
 	].join('');
 
+	const key = [prefixPath, objectLocation].join('/');
+
 	const params = {
 		Bucket: bucketName,
-		Key: [prefixPath, objectLocation].join('/'),
+		Key: key,
 		Body: dataToStore,
 		ContentType: 'application/json',
 	};
 
-	return await s3
-		.send(new PutObjectCommand(params))
-		.then((_) => objectLocation);
+	return await s3.send(new PutObjectCommand(params)).then(() => key);
 };
 
 export const getCapiToken = async () =>

--- a/packages/shared-types.ts
+++ b/packages/shared-types.ts
@@ -1,1 +1,19 @@
-export type EditionKey = 'AUS';
+/**
+ * The `EditionKey` type is shared between the `cdk` package and the
+ * `pressreader` package because each edition has its own lambda so we need to
+ * pass the edition key to each lambda so that it can look up the correct
+ * edition config.
+ *
+ * Sharing the type here gives us some security that the edition
+ * data will exist in the lambdas's `editionConfigs` object. Adding a new
+ * edition to the `editionConfigs` object will require a change to this type,
+ * e.g. to add an `EU` edition, update as follows: `const EDITION_KEYS = ['AUS', 'US', 'EU']`.
+ */
+const EDITION_KEYS = ['AUS', 'US'] as const;
+
+export type EditionKey = (typeof EDITION_KEYS)[number];
+
+export function isEditionKey(key: string | undefined): key is EditionKey {
+	// @ts-expect-error This is a type predicate so we should allow that key might not be a valid EditionKey
+	return !!key && EDITION_KEYS.includes(key);
+}

--- a/packages/shared-types.ts
+++ b/packages/shared-types.ts
@@ -1,0 +1,1 @@
+export type EditionKey = 'AUS';


### PR DESCRIPTION
## What does this change?

Configure a lambda per config / write destination in order to run the "new" and "old" paths in parallel and at the same time provide a way to publish different editions.

## How to test

Deploy this to INFRA and ensure that the infrastructure deploys, the lambdas run when triggered via a test run, and that the expected data is available at the appropriate endpoints with the API key retrievable from API gateway:

- https://pressreader.gutools.co.uk/US/20230606
- https://pressreader.gutools.co.uk/AUS/20230606

## How can we measure success?

Pressreader are able to use the data provided by the lambda to produce print on demand papers, and eventually can use the API gateway endpoints without further work.

## Have we considered potential risks?

We need to check that the data the new method produces is functionally substitutable from the old data, and that we will be alerted if there are errors (we can test this by simulating an alert state).