### PR TITLE
Launch AUS lambda, writing to legacy location

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -20,7 +20,7 @@ new PressReader(app, 'PressReader-INFRA', {
 		},
 		{
 			editionKey: 'AUS',
-			s3PrefixPath: ['testing'],
+			s3PrefixPath: [],
 			bucketName: 'press-reader-aus-configs',
 		},
 		{


### PR DESCRIPTION
## What?
Remove 'testing' prefix from AUS-old path

## Why?
In effect this will 'launch' the new version of the AUS lambda, by
directing its outputs to the same place that the existing AppleScript
version does currently.

