### PR TITLE
If prefixPath is empty, just use objectLocation

### DIFF
--- a/packages/pressreader/src/util.ts
+++ b/packages/pressreader/src/util.ts
@@ -11,7 +11,8 @@ export const putDataToS3 = async (dataToStore: string, date: Date) => {
 		'.json',
 	].join('');
 
-	const key = [prefixPath, objectLocation].join('/');
+	const key =
+		prefixPath === '' ? objectLocation : [prefixPath, objectLocation].join('/');
 
 	const params = {
 		Bucket: bucketName,


### PR DESCRIPTION
## What does this change?

This fixes an issue where if `prefixPath` is empty a leading slash is appended to the path written to S3 resulting in "/" becoming the "folder name" for the object 😖 

## How to test

- [x] Deploy this change, observe it publish to the correct location.

## How can we measure success?

Files are published to their correct location with and without a prefix.