### PR TITLE
Launch US lambda, writing to legacy location

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -25,7 +25,7 @@ new PressReader(app, 'PressReader-INFRA', {
 		},
 		{
 			editionKey: 'US',
-			s3PrefixPath: ['testing'],
+			s3PrefixPath: [],
 			bucketName: 'press-reader-us-configs',
 		},
 	],


### PR DESCRIPTION
## What?
Remove 'testing' prefix from US-old path

After this is merged we should:
- [ ] Trigger lambda manually and observe that the expected file is created.
- [ ] Turn off the existing legacy pressreader service writing the US file

Follows: https://github.com/guardian/pressreader/pull/22

## Why?
This will 'launch' the new version of the US lambda, by
directing its outputs to the same place that the existing AppleScript
version does currently.

