### PR TITLE
Adds some documentation on config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,12 @@ which is extended from the [AWS Cloud Development Kit (CDK)](https://aws.amazon.
 ![Pressreader architecture](./pressreader-arch-230523.png)
 [LucidChart Link](https://lucid.app/lucidchart/4040f7d6-661a-4867-ade0-93ca657a5580/edit?viewport_loc=-103%2C-73%2C1859%2C946%2C0_0&invitationId=inv_0cb12b70-eb29-4a54-8838-b4d32e07d820)
 
+## Configuration
+
+The Pressreader lambdas configuration is in the [Pressreader GitHub repository](https://github.com/guardian/pressreader/tree/main/packages/pressreader/src/editionConfigs), and configuration changes are rolled out by creating a PR for changes, merging that PR and having the changes by released by continuous delivery.
+
+There is further documentation on [how the configuration effects what is published](./pressreader-config.md).
+
 ## Logs & Monitoring
 
 Lambda logs can be viewed using the [`app: pressreader` filter in Kibana on logs.gutools.co.uk](https://logs.gutools.co.uk/s/newsroom-resilience/goto/8f38a860-fb94-11ed-a6e5-05ce52e0b77b).

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ which is extended from the [AWS Cloud Development Kit (CDK)](https://aws.amazon.
 
 The Pressreader lambdas configuration is in the [Pressreader GitHub repository](https://github.com/guardian/pressreader/tree/main/packages/pressreader/src/editionConfigs), and configuration changes are rolled out by creating a PR for changes, merging that PR and having the changes by released by continuous delivery.
 
-There is further documentation on [how the configuration effects what is published](./pressreader-config.md).
+There is further documentation on [how the configuration affects what is published](./pressreader-config.md).
 
 ## Logs & Monitoring
 

--- a/docs/pressreader-config.md
+++ b/docs/pressreader-config.md
@@ -1,0 +1,73 @@
+# Which content is published?
+
+The service reads [config files](https://github.com/guardian/pressreader/tree/main/packages/pressreader/src/editionConfigs) to locate content.
+
+## Sections
+
+```js
+export const ausConfig: PressReaderEditionConfig = {
+	sections: [
+        { '...': '...'},
+        { '...': '...'},
+        { '...': '...'},
+    ]
+}
+```
+
+Top level array called “sections” contains the definitions necessary to create the index file that Pressreader consults.
+
+Each section contains four keys:
+
+```js
+{
+    displayName: 'Headlines',
+	maximumArticleCount: 12,
+	frontSources: [{'...':'...'}],
+    capiSources: [],
+}
+```
+
+- `displayName`: the name of the section as seen by the reader
+- `maximumArticleCount`: the maximum number of articles we should include in the section
+- `frontSources`: the necessary details to address fronts containers to look for content, you can have multiple fronts sources.
+- `capiSources`: the CAPI queries to use to look for content. You can have multiple CAPI sources.
+
+## Fronts sources
+
+Each ‘fronts’ source has three keys.
+
+```js
+{
+    collectionIndexes: [0],
+    collectionNames: ['Headlines'],
+    sectionContentURL: 'http://api.nextgen.guardianapps.co.uk/au/lite.json',
+}
+```
+
+- `sectionContentURL`: the URL of the API to consult for the collections information
+- `collectionIndexes`: A list of integers describing which container to fetch data from
+- `collectionNames`: A list of strings with the names of which containers to fetch data from
+
+## Capi Sources
+
+This is an array of strings each of which defines a CAPI search to use to locate content for the section.
+
+```js
+{
+    ...: '...',
+    capiSources: [
+        'search?tag=tone%2Feditorials&production-office=aus&order-by=newest',
+        'search?tag=tone%2Feditorials&order-by=newest',
+    ],
+}
+```
+
+## Article selection logic
+
+Each section is processed in the order it is defined in the config file. Each section’s lists of articles is created by:
+
+1. Consulting any fronts containers referenced by index
+1. Consulting any fronts containers referenced by name
+1. Consulting CAPI queries in the order they are supplied in the configuration
+
+If an article has already been included in a section then it is ignored. If the content type is not an article, it is ignored. Once the maximum article count has been met, or the sources exhausted we move on to the next section.

--- a/docs/pressreader-config.md
+++ b/docs/pressreader-config.md
@@ -74,5 +74,7 @@ Articles are also excluded if:
 
 1. They were published more than 24 hours ago
 1. They have a word count that's shorter than the `MIN_WORDCOUNT` that's set globally
-
-If an article has already been included in a section then it is ignored. If the content type is not an article, it is ignored. Once the maximum article count has been met, or the sources exhausted we move on to the next section.
+2. If an article has already been included in a section
+3. If the content type is not an article
+   
+Once the maximum article count has been met, or the sources exhausted we move on to the next section.

--- a/docs/pressreader-config.md
+++ b/docs/pressreader-config.md
@@ -70,4 +70,9 @@ Each section is processed in the order it is defined in the config file. Each se
 1. Consulting any fronts containers referenced by name
 1. Consulting CAPI queries in the order they are supplied in the configuration
 
+Articles are also excluded if:
+
+1. They were published more than 24 hours ago
+1. They have a word count that's shorter than the `MIN_WORDCOUNT` that's set globally
+
 If an article has already been included in a section then it is ignored. If the content type is not an article, it is ignored. Once the maximum article count has been met, or the sources exhausted we move on to the next section.


### PR DESCRIPTION
## What does this change?

This change adds some documentation created by David B that describes how the config affects what is published by the Pressreader lambdas.

## How to test

[Read the documentation.](https://github.com/guardian/pressreader/blob/rk/config-docs/docs/pressreader-config.md)

## How can we measure success?

Does the documentation make sense? Could someone new to the project use it to make sensible changes?