### PR TITLE
Reduce lambda alarm threshold

### DIFF
--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -863,7 +863,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
         "AlarmName": "pressreader-AUS-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
+        "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
@@ -1244,7 +1244,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
         "AlarmName": "pressreader-AUS-old-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
+        "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
@@ -1699,7 +1699,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
         "AlarmName": "pressreader-US-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
+        "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
@@ -1970,7 +1970,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
         "AlarmName": "pressreader-US-old-TEST-ErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 120,
+        "EvaluationPeriods": 1,
         "Metrics": [
           {
             "Expression": "100*m1/m2",

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -191,8 +191,8 @@ export class PressReader extends GuStack {
 				alarmDescription: `Triggers if there are errors from ${appName} on ${this.stage}`,
 				snsTopicName: alarmSnsTopic.topicName,
 				toleratedErrorPercentage: 1,
-				// Requires 2 failures in a row based on lambda scheduled to run once an hour
-				numberOfMinutesAboveThresholdBeforeAlarm: 120,
+				// Notify immediately if any failure occurs
+				numberOfMinutesAboveThresholdBeforeAlarm: 1,
 			};
 
 			const s3PutPolicyStatement = new PolicyStatement({


### PR DESCRIPTION
## What does this change?

This change will cause an alarm state to be set as soon as the lambda errors (within the first minute), rather than waiting for the 2 hour period to elapse.

## How to test

Deploy this change, and update the configuration for the new US lamdba to point to a secret location that does not exist. "Test" the lambda execution. Observe whether the alarm goes into Alarm.

<img width="1292" alt="Screenshot 2023-06-14 at 10 33 40" src="https://github.com/guardian/pressreader/assets/953792/003804a6-9f3c-4082-ad6b-d227a059bcfd">

## How can we measure success?

We're alerted in a timely fashion if there is an error in the Pressreader lambdas.
