### PR TITLE
Fix running pressreader lambda locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       - "./.tmp:/tmp/localstack"
       - ./localstack:/docker-entrypoint-initaws.d
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - $HOME/.aws/credentials:/root/.aws/credentials:ro

--- a/localstack/resources.sh
+++ b/localstack/resources.sh
@@ -2,13 +2,20 @@
 
 export AWS_DEFAULT_REGION=eu-west-1
 
+# Set CAPI_API_KEY from real AWS values
+CAPI_API_KEY=$(AWS_REGION=eu-west-1 AWS_PROFILE=printProd \
+  aws secretsmanager get-secret-value \
+  --secret-id /DEV/print-production/pressreader/capiToken \
+  --query "SecretString" \
+  --output text)
+
 awslocal secretsmanager delete-secret \
   --secret-id "/DEV/print-production/pressreader/capiToken" \
   --force-delete-without-recovery || true
 
 awslocal secretsmanager create-secret \
   --name /DEV/print-production/pressreader/capiToken \
-  --secret-string changeme 
+  --secret-string $CAPI_API_KEY 
 
 # Create our telemetry bucket for localstack
 awslocal s3 mb s3://dev-pressreader  || true

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -9,7 +9,7 @@
 		"@types/node": "18.13.0"
 	},
 	"scripts": {
-		"dev": "ts-node-dev --respawn src/handler.ts",
+		"dev": "EDITION_KEY=US ts-node-dev src/handler.ts",
 		"typecheck": "tsc -noEmit",
 		"format": "prettier --write \"src/**/*.ts\"",
 		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:aws-sdk --platform=node",

--- a/packages/pressreader/src/editionConfigs/index.ts
+++ b/packages/pressreader/src/editionConfigs/index.ts
@@ -1,4 +1,4 @@
-import type { EditionKey } from 'packages/shared-types';
+import type { EditionKey } from '../../../shared-types';
 import type { PressReaderEditionConfig } from '../types/PressReaderTypes';
 import { ausConfig } from './ausConfig';
 import { usConfig } from './usConfig';

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -1,4 +1,4 @@
-import { isEditionKey } from 'packages/shared-types';
+import { isEditionKey } from '../../shared-types';
 import { editionKey } from './constants';
 import { editionConfigs } from './editionConfigs';
 import { editionProcessor } from './processEdition';


### PR DESCRIPTION
## What does this change?

This change fixes a bug where the pressreader lambda could not be run locally:

```
➜  pressreader git:(main) npm run dev

> pressreader@1.0.0 dev
> ts-node-dev --respawn src/handler.ts

[INFO] 10:53:12 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.1, typescript ver. 4.9.5)
Error: Cannot find module 'packages/shared-types'
Require stack:
- /Users/Robert_kenny/workspace/pressreader/packages/pressreader/src/handler.ts
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1039:15)
    at Function.Module._load (node:internal/modules/cjs/loader:885:27)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/Robert_kenny/workspace/pressreader/packages/pressreader/src/handler.ts:1:1)
    at Module._compile (node:internal/modules/cjs/loader:1218:14)
    at Module._compile (/Users/Robert_kenny/workspace/pressreader/node_modules/source-map-support/source-map-support.js:521:25)
    at Module.m._compile (/private/var/folders/hs/s35lhxtd6lbfy84ks8cyt7h40000gp/T/ts-node-dev-hook-1256526435840144.js:69:33)
    at Module._extensions..js (node:internal/modules/cjs/loader:1272:10)
    at require.extensions..jsx.require.extensions..js (/private/var/folders/hs/s35lhxtd6lbfy84ks8cyt7h40000gp/T/ts-node-dev-hook-1256526435840144.js:114:20)
[ERROR] 10:53:12 Error: Cannot find module 'packages/shared-types'
Require stack:
- /Users/Robert_kenny/workspace/pressreader/packages/pressreader/src/handler.ts
```

We update the references to `shared-types.ts` to use relative paths which allows `npm run dev` & `npm run typecheck` to run successfully.

In addition we add an update to `resources.sh` that inserts the dev secret CAPI key into Secrets Manager in Localstack so that it can make succesfull CAPI queries when run locally.

## How to test

Checkout this branch, run `npm run dev` from the `pressreader` package (after setting print-production AWS credentials from Janus).

## How can we measure success?

Developers can work on this project locally, resulting in faster iterations and quicker development.
