### PR TITLE
Read CAPI key from ~/.gu config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,4 @@ services:
       - "./.tmp:/tmp/localstack"
       - ./localstack:/docker-entrypoint-initaws.d
       - "/var/run/docker.sock:/var/run/docker.sock"
-      - $HOME/.aws/credentials:/root/.aws/credentials:ro
+      - $HOME/.gu/pressreader:/root/.gu/pressreader:ro

--- a/localstack/resources.sh
+++ b/localstack/resources.sh
@@ -3,11 +3,7 @@
 export AWS_DEFAULT_REGION=eu-west-1
 
 # Set CAPI_API_KEY from real AWS values
-CAPI_API_KEY=$(AWS_REGION=eu-west-1 AWS_PROFILE=printProd \
-  aws secretsmanager get-secret-value \
-  --secret-id /DEV/print-production/pressreader/capiToken \
-  --query "SecretString" \
-  --output text)
+CAPI_API_KEY=$(cat ~/.gu/pressreader/capiKey)
 
 awslocal secretsmanager delete-secret \
   --secret-id "/DEV/print-production/pressreader/capiToken" \

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,6 +4,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=${DIR}/..
+GU_CONFIG_LOCATION=~/.gu/pressreader/
 
 setup_git_hook() {
   echo "Setting up pre-push hook"
@@ -41,6 +42,19 @@ check_node_version() {
   fi
 }
 
+create_gu_config() {
+  echo "Creating config in $GU_CONFIG_LOCATION"
+  mkdir -p $GU_CONFIG_LOCATION
+
+  CAPI_API_KEY=$(AWS_REGION=eu-west-1 AWS_PROFILE=printProd \
+    aws secretsmanager get-secret-value \
+    --secret-id /DEV/print-production/pressreader/capiToken \
+    --query "SecretString" \
+    --output text)
+
+  echo $CAPI_API_KEY > $GU_CONFIG_LOCATION/capiKey
+}
+
 install_node_deps() {
   echo "Installing node dependencies"
   npm i
@@ -49,5 +63,6 @@ install_node_deps() {
 setup_git_hook
 check_node_version
 install_node_deps
+create_gu_config
 
 echo "You're all set up!"


### PR DESCRIPTION
## What does this change?

Mounting the AWS credentials into the localstack container gives it to much power and also requires you to have an internet connection, AND to have setup Janus credentials every time.

This change simplifies and secures things.

## How to test

Check this out, run `./script/setup` with print-production Janus credentials set, then attempt to run `npm run dev` from within the pressreader package.

## How can we measure success?

More secure, and simpler process for running the lambda locally.