### PR TITLE
Add Cloudwatch alarm for lookup failures

### DIFF
--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "GuS3Bucket",
       "GuCertificate",
       "GuCname",
+      "GuAlarm",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
@@ -205,6 +206,44 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
+    },
+    "CollectionLookupFailureAlarmD0550C39": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 1,
+        "EvaluationPeriods": 1,
+        "MetricName": "CollectionLookupFailure",
+        "Namespace": "AWS/Lambda",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "PressReaderAPI27D6A559": {
       "Properties": {
@@ -793,6 +832,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "AUS",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
             "PREFIX_PATH": "data/AUS",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1092,6 +1132,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1174,6 +1219,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "AUS",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
             "PREFIX_PATH": "",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1418,6 +1464,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1629,6 +1680,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "US",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
             "PREFIX_PATH": "data/US",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1928,6 +1980,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ],
               },
             },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -2103,6 +2160,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "US",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
             "PREFIX_PATH": "",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -2306,6 +2364,11 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                   ],
                 ],
               },
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -208,7 +208,7 @@ export class PressReader extends GuStack {
 				alarmDescription: `Triggers if there are errors from ${appName} on ${this.stage}`,
 				snsTopicName: alarmSnsTopic.topicName,
 				toleratedErrorPercentage: 1,
-				// Requires 2 failures in a row based on lambda scheduled to run once an hour
+				// Notify immediately if any failure occurs
 				numberOfMinutesAboveThresholdBeforeAlarm: 1,
 			};
 

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -1,4 +1,5 @@
 import { GuCertificate } from '@guardian/cdk/lib/constructs/acm';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch/alarm';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns/';
@@ -8,6 +9,7 @@ import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import type { DomainName } from 'aws-cdk-lib/aws-apigateway';
 import { AwsIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import {
 	Effect,
@@ -158,10 +160,25 @@ export class PressReader extends GuStack {
 			description: 'The CAPI token used to retrieve content',
 		});
 
+		// metrics
+		const collectionLookupFailureMetric = new Metric({
+			namespace: 'AWS/Lambda',
+			metricName: 'CollectionLookupFailure',
+		});
+
 		// alarms
 		const alarmSnsTopic = new Topic(this, `${appName}-email-alarm-topic`);
 		const alertEmail = `newsroom.resilience+alerts@guardian.co.uk`;
 		alarmSnsTopic.addSubscription(new EmailSubscription(alertEmail));
+
+		new GuAlarm(this, 'CollectionLookupFailureAlarm', {
+			app: appName,
+			metric: collectionLookupFailureMetric,
+			threshold: 1,
+			evaluationPeriods: 1,
+			datapointsToAlarm: 1,
+			snsTopicName: alarmSnsTopic.topicName,
+		});
 
 		// scheduled lambda
 		const capiSecretGetPolicyStatement = new PolicyStatement({
@@ -191,7 +208,7 @@ export class PressReader extends GuStack {
 				alarmDescription: `Triggers if there are errors from ${appName} on ${this.stage}`,
 				snsTopicName: alarmSnsTopic.topicName,
 				toleratedErrorPercentage: 1,
-				// Notify immediately if any failure occurs
+				// Requires 2 failures in a row based on lambda scheduled to run once an hour
 				numberOfMinutesAboveThresholdBeforeAlarm: 1,
 			};
 
@@ -222,6 +239,7 @@ export class PressReader extends GuStack {
 						BUCKET_NAME: lambdaBucket.bucketName,
 						CAPI_SECRET_LOCATION: capiSecret.secretName,
 						EDITION_KEY: config.editionKey,
+						FAILURE_METRIC_NAME: collectionLookupFailureMetric.metricName,
 						PREFIX_PATH: config.s3PrefixPath.join('/'),
 					},
 					fileName: `pressreader.zip`,
@@ -233,6 +251,8 @@ export class PressReader extends GuStack {
 
 			scheduledLambda.addToRolePolicy(capiSecretGetPolicyStatement);
 			scheduledLambda.addToRolePolicy(s3PutPolicyStatement);
+
+			Metric.grantPutMetricData(scheduledLambda);
 		});
 	}
 }

--- a/packages/pressreader/src/constants.ts
+++ b/packages/pressreader/src/constants.ts
@@ -1,6 +1,7 @@
 export const awsRegion = process.env.AWS_REGION ?? 'eu-west-1';
 export const bucketName = process.env.BUCKET_NAME ?? 'dev-pressreader';
 export const prefixPath = process.env.PREFIX_PATH ?? '';
+export const failureMetricArn = process.env.FAILURE_METRIC_NAME ?? '';
 export const editionKey = process.env.EDITION_KEY;
 export const capiSecretLocation =
 	process.env.CAPI_SECRET_LOCATION ??


### PR DESCRIPTION
Adds the infrastructure to allow us to send alerts when we spot a failure to lookup a collection from the config:

1. A new metric, called `CollectionLookupFailure`.
2. An alarm which will notify the existing email alert SNS topic for this project.
3. Make a new environmental variable available to the Lambda handler, so that it can address the new metric.

Actual use of the new metric and alarm will be added in a subsequent PR.

## How to test

Look at the diffs in the config output as part of our snapshot test. Beyond that, I'm not sure we can test this properly without merging and deploying it, because we don't have a CODE stage as things stand.

## How can we measure success?

We will be able to receive alerts when the lambda tries to look up collections which don't exist.

