### PR TITLE
Look up collections via id instead of name/index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 node_modules
 *.tsbuildinfo
 .tmp
+scripts/dev-untracked

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -9,7 +9,7 @@
 		"@types/node": "18.13.0"
 	},
 	"scripts": {
-		"dev": "EDITION_KEY=US ts-node-dev src/handler.ts",
+		"dev": "EDITION_KEY=US PREFIX_PATH=us/data ts-node-dev src/handler.ts",
 		"typecheck": "tsc -noEmit",
 		"format": "prettier --write \"src/**/*.ts\"",
 		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:aws-sdk --platform=node",

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -9,7 +9,7 @@
 		"@types/node": "18.13.0"
 	},
 	"scripts": {
-		"dev": "EDITION_KEY=US PREFIX_PATH=us/data ts-node-dev src/handler.ts",
+		"dev": "EDITION_KEY=US PREFIX_PATH=data/us ts-node-dev src/handler.ts",
 		"typecheck": "tsc -noEmit",
 		"format": "prettier --write \"src/**/*.ts\"",
 		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:aws-sdk --platform=node",

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -7,10 +7,15 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [0],
-					collectionNames: ['Headlines'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
+					collectionIds: [
+						{
+							id: 'c56b1db1-89eb-4143-8406-0bfbc75f4c58',
+							name: 'Palette styles new do not delete',
+						},
+						{ id: 'a22fa7fc-684f-484a-90bf-3f5aa4b711f7', name: 'Headlines' },
+					],
 				},
 			],
 			capiSources: [],
@@ -20,16 +25,28 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 14,
 			frontSources: [
 				{
-					collectionIndexes: [0],
-					collectionNames: ['Australia news'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+					collectionIds: [
+						{
+							id: 'ee319aab-a40c-4bc5-a40d-fa8f0b8f2b88',
+							name: 'Australia news',
+						},
+						{
+							id: 'ee319aab-a40c-4bc5-a40d-fa8f0b8f2b88',
+							name: 'Australia news',
+						},
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['Across the country'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
+					collectionIds: [
+						{
+							id: '5d60fb3d-9bb2-439b-81d4-3bd4d625165a',
+							name: 'Across the country',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -39,10 +56,14 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['Australian politics'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/australia-news/lite.json',
+					collectionIds: [
+						{
+							id: '47eb1794-2f5a-490d-a3af-425d88e2d2f2',
+							name: 'Australian politics',
+						},
+					],
 				},
 			],
 			capiSources: [
@@ -54,10 +75,15 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 16,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['Headlines', 'Around the world'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/international/lite.json',
+					collectionIds: [
+						{ id: '10f21d96-18f6-426f-821b-19df55dfb831', name: 'Headlines' },
+						{
+							id: '2c19b8b3-6503-4a3b-8821-9a04898b5243',
+							name: 'Around the world',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -73,22 +99,30 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 14,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['Columnists', 'Indigenous Australia', 'Opinion'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/commentisfree/lite.json',
+					collectionIds: [
+						{ id: '856d1576-46f0-4cbb-af2a-ec83f0eaa9ff', name: 'Columnists' },
+						{
+							id: '644f8b13-1b3b-42fd-b4a4-79309849b6f4',
+							name: 'Indigenous Australia',
+						},
+						{ id: 'au/commentisfree/regular-stories', name: 'Opinion' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['Opinion'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
+					collectionIds: [
+						{ id: 'au-alpha/contributors/feature-stories', name: 'Opinion' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['World view'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/commentisfree/lite.json',
+					collectionIds: [
+						{ id: 'a3194998-0d92-49a5-aaa2-c3b7cd26bafc', name: 'World view' },
+					],
 				},
 			],
 			capiSources: [],
@@ -98,10 +132,21 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 6,
 			frontSources: [
 				{
-					collectionIndexes: [0, 2, 1, 3, 5],
-					collectionNames: [],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/business/lite.json',
+					collectionIds: [
+						{ id: 'c7bc8956-7d55-4968-840b-e23e44f0e18b', name: 'News' },
+						{ id: '0a1173d4-8904-4221-87e6-3f8b22ebc29e', name: 'In depth' },
+						{
+							id: 'a7de79b6-5b1b-49d1-8e35-cd3725134c9c',
+							name: 'Greg Jericho',
+						},
+						{
+							id: '02dcfceb-accb-42a4-a998-4cb1c935738f',
+							name: 'Guardian Labs',
+						},
+						{ id: 'a6be553e-2a64-4bb0-9678-b81227eae5e1', name: 'World news' },
+					],
 				},
 			],
 			capiSources: [],
@@ -120,16 +165,18 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: [
-						'Environment',
-						'World news',
-						'Opinion',
-						'Global view',
-						'Investigations and analysis',
-					],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/environment/lite.json',
+					collectionIds: [
+						{ id: '586be7cd-1f83-4e71-8ff3-f2610d2d71d9', name: 'Environment' },
+						{ id: 'b2aab4ef-ccab-4a24-bade-419e8222d789', name: 'World news' },
+						{ id: '99b67485-70ef-4f75-be86-15843a8d0207', name: 'Opinion' },
+						{ id: 'bd261fb2-3d6d-465e-92e8-e3bf88b3ee67', name: 'Global view' },
+						{
+							id: '5561a451-dd53-4114-a957-2c8a18f87132',
+							name: 'Investigations and analysis',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -139,10 +186,13 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['Science', 'News', 'Key issues'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/science/lite.json',
+					collectionIds: [
+						{ id: 'e9c7-cf23-23b1-363b', name: 'Science' },
+						{ id: 'e7623e60-63fe-4f52-8295-3692ef272beb', name: 'News' },
+						{ id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1', name: 'Key issues' },
+					],
 				},
 			],
 			capiSources: [
@@ -155,17 +205,22 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: [
-						'Technology',
-						'Australian tech',
-						'In depth',
-						'Opinion & analysis',
-						'Inside Silicon Valley',
-						'Spotlight',
-					],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/technology/lite.json',
+					collectionIds: [
+						{ id: '6bb3-9f76-43bd-4213', name: 'Technology' },
+						{
+							id: '86be3263-a4db-4bb8-aaa9-7c9662094958',
+							name: 'Australian tech',
+						},
+						{ id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d', name: 'In depth' },
+						{ id: '8185-0956-87b3-126d', name: 'Opinion & analysis' },
+						{
+							id: 'c6a8df3e-7685-4bca-856d-f5b0c59163d0',
+							name: 'Inside Silicon Valley',
+						},
+						{ id: 'cff4aa48-dd86-433f-bc11-eb15abae55fc', name: 'Spotlight' },
+					],
 				},
 			],
 			capiSources: [],
@@ -175,16 +230,21 @@ export const ausConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 14,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['Sport'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
+					collectionIds: [{ id: 'c45d-318f-896c-3a85', name: 'Sport' }],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['Sport', 'Features', 'International sport'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/sport/lite.json',
+					collectionIds: [
+						{ id: '0644cd79-4d8b-4d20-a1ed-13f8b7ed4373', name: 'Sport' },
+						{ id: 'f40bb225-86ab-4d85-a98d-bb2ea11fb453', name: 'Features' },
+						{
+							id: 'a368f61c-8bfb-4d5d-9a88-f76123cd22c9',
+							name: 'International sport',
+						},
+					],
 				},
 			],
 			capiSources: [],

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -28,10 +28,6 @@ export const ausConfig: PressReaderEditionConfig = {
 							id: 'ee319aab-a40c-4bc5-a40d-fa8f0b8f2b88',
 							name: 'Australia news',
 						},
-						{
-							id: 'ee319aab-a40c-4bc5-a40d-fa8f0b8f2b88',
-							name: 'Australia news',
-						},
 					],
 				},
 				{

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -10,10 +10,6 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
-						{
-							id: 'c56b1db1-89eb-4143-8406-0bfbc75f4c58',
-							name: 'Palette styles new do not delete',
-						},
 						{ id: 'a22fa7fc-684f-484a-90bf-3f5aa4b711f7', name: 'Headlines' },
 					],
 				},

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -7,10 +7,15 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 10,
 			frontSources: [
 				{
-					collectionIndexes: [0],
-					collectionNames: ['headlines'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
+					collectionIds: [
+						{
+							id: '7c0f56e8-d4c4-408f-ba58-c29508c8cf5e',
+							name: 'Palette styles new do not delete',
+						},
+						{ id: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026', name: 'Headlines' },
+					],
 				},
 			],
 			capiSources: [],
@@ -20,16 +25,14 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['US news'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['across the country'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
+					collectionIds: [
+						{
+							id: '5a59a4e5-074e-4a2a-8bbe-2743e07ae30f',
+							name: 'Across the country',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -39,27 +42,18 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['headlines'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['US politics'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+					collectionIds: [
+						{ id: '436ed09d-614f-4418-8500-d1fa9e20404e', name: 'US politics' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: [
-						'in depth',
-						'Trump administration',
-						'the resistance',
-						'policy',
-					],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
+					collectionIds: [
+						{ id: '7e70e9f4-1c60-42e1-85ee-01c8621a0acc', name: 'In depth' },
+					],
 				},
 			],
 			capiSources: [],
@@ -69,22 +63,14 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['world news'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/world/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['around the world'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['around the world'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/world/lite.json',
+					collectionIds: [
+						{
+							id: '2e2035e0-7da9-4172-b0b4-787f3e2a4549',
+							name: 'Around the world',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -94,46 +80,33 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['opinion', 'spotlight'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
+					collectionIds: [
+						{ id: '98df412d-b0e7-4d9a-98c2-062642823e94', name: 'Opinion' },
+						{ id: 'us-alpha/features/feature-stories', name: 'Spotlight' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['columnists & contributors', 'opinion'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/commentisfree/lite.json',
+					collectionIds: [
+						{ id: 'us-alpha/contributors/feature-stories', name: 'Opinion' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['opinion & analysis'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['opinion'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
+					collectionIds: [
+						{ id: '21450e4f-a452-4601-a4b3-03ba00b5da1a', name: 'Opinion' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['opinion & analysis'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/world/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['explore'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
-				},
-				{
-					collectionIndexes: [],
-					collectionNames: ['spotlight', 'you may have missed'],
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us/commentisfree/lite.json',
+					collectionIds: [
+						{ id: '5fd45b04-c512-4a8c-a9b5-cc07a6097049', name: 'Explore' },
+					],
 				},
 			],
 			capiSources: [],
@@ -149,28 +122,36 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['US business'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+					collectionIds: [
+						{ id: 'b0e0bc29-41b5-4dd7-8a5e-f5d4129971a7', name: 'US business' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['business ', 'in depth'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/business/lite.json',
+					collectionIds: [
+						{ id: '2be3f39d-9032-4197-9479-fb6da23599ff', name: 'Business ' },
+						{ id: '6d3daff4-2a4b-46e9-a972-2fe41195db94', name: 'In depth' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['sustainable business', 'featured series '],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/sustainable-business/lite.json',
+					collectionIds: [
+						{ id: '7f3c-ab04-684f-76a2', name: 'sustainable business' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['around the world'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/business/lite.json',
+					collectionIds: [
+						{
+							id: '723f35eb-2ab4-4fff-941d-7718b2da4fee',
+							name: 'Around the world',
+						},
+					],
 				},
 			],
 			capiSources: [],
@@ -189,22 +170,29 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['arts', 'talking points', 'people'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/culture/lite.json',
+					collectionIds: [
+						{ id: 'us/culture/regular-stories', name: 'Arts' },
+						{
+							id: '747c8b96-288a-449a-9e54-be657895d20d',
+							name: 'Talking points',
+						},
+						{ id: '84c18e8f-0bc4-4797-bd3c-57664bd29a53', name: 'People' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['film', 'talking points', 'news'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/film/lite.json',
+					collectionIds: [
+						{ id: '1ce8-6c50-425f-9d32', name: 'Film' },
+						{ id: 'b073-c5d7-c8a9-1e32', name: 'News' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['music', 'talking points', 'news'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/music/lite.json',
+					collectionIds: [{ id: 'ee1e-171a-2d93-c8c4', name: 'Music' }],
 				},
 			],
 			capiSources: [],
@@ -214,16 +202,12 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: [
-						'fashion',
-						'talking points',
-						'news',
-						'you may have missed',
-						'the shows',
-					],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/fashion/lite.json',
+					collectionIds: [
+						{ id: 'eb83-f340-cc50-b311', name: 'Fashion' },
+						{ id: '10419891-2ba1-4eb5-bf53-8933e27ffd1f', name: 'The shows' },
+					],
 				},
 			],
 			capiSources: [],
@@ -233,17 +217,11 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 6,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: [
-						'environment',
-						'talking points',
-						'featured series',
-						'this land is your land',
-						'keystone XL pipeline',
-						'energy',
-					],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/environment/lite.json',
+					collectionIds: [
+						{ id: '2b027145-7523-4032-a954-5b3121216996', name: 'Environment' },
+					],
 				},
 			],
 			capiSources: [],
@@ -253,10 +231,13 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 6,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['science', 'blog network', 'news', 'key issues'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/science/lite.json',
+					collectionIds: [
+						{ id: 'e9c7-cf23-23b1-363b', name: 'Science' },
+						{ id: 'e7623e60-63fe-4f52-8295-3692ef272beb', name: 'News' },
+						{ id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1', name: 'Key issues' },
+					],
 				},
 			],
 			capiSources: [
@@ -269,10 +250,12 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 8,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['technology', 'in depth'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/technology/lite.json',
+					collectionIds: [
+						{ id: '6bb3-9f76-43bd-4213', name: 'Technology' },
+						{ id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d', name: 'In depth' },
+					],
 				},
 			],
 			capiSources: [],
@@ -282,28 +265,37 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['US sports'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+					collectionIds: [
+						{ id: 'c8132ecb-e937-4032-b69d-908f09c838a0', name: 'US sports' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['across the country', 'sports'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/sport/lite.json',
+					collectionIds: [
+						{
+							id: '7f429d4d-0fd8-4bcb-a44c-e90a816847e3',
+							name: 'Across the country',
+						},
+						{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' },
+					],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['sports'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
+					collectionIds: [{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' }],
 				},
 				{
-					collectionIndexes: [],
-					collectionNames: ['around the world'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/sport/lite.json',
+					collectionIds: [
+						{
+							id: '0e5f4538-b4cf-4c7b-be44-92966eb638dd',
+							name: 'Around the world',
+						},
+					],
 				},
 			],
 			capiSources: [
@@ -318,10 +310,9 @@ export const usConfig: PressReaderEditionConfig = {
 			maximumArticleCount: 12,
 			frontSources: [
 				{
-					collectionIndexes: [],
-					collectionNames: ['football'],
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/football/lite.json',
+					collectionIds: [{ id: '1a78-862a-834b-b1d3', name: 'Football' }],
 				},
 			],
 			capiSources: ['search?tag=football%2Fmls&order-by=newest'],

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -10,10 +10,6 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
-						{
-							id: '7c0f56e8-d4c4-408f-ba58-c29508c8cf5e',
-							name: 'Palette styles new do not delete',
-						},
 						{ id: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026', name: 'Headlines' },
 					],
 				},

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -23,6 +23,7 @@ export const main = async () => {
 			capiKey: capiToken,
 			baseCapiUrl: 'https://content.guardianapis.com',
 		},
+		collectionMismatchAlarm: () => null,
 	});
 
 	const data = await processor.run();

--- a/packages/pressreader/src/processFrontData.test.ts
+++ b/packages/pressreader/src/processFrontData.test.ts
@@ -41,34 +41,85 @@ const pressedPage: PressedFrontPage = {
 	collections: [collection1, collection2],
 };
 
+function collectionMismatchAlarm() {
+	console.warn('collection mismatch alarm');
+}
+
 describe('processFrontData', () => {
 	it('should get stories from each of the matching collections', () => {
 		const frontConfigWithData = {
-			collectionIndexes: [0],
-			collectionNames: ['my container'],
 			sectionContentURL: 'sectionContentURL',
+			collectionIds: [
+				{
+					id: 'abc',
+					name: 'name',
+				},
+				{
+					id: 'def',
+					name: 'my container',
+				},
+			],
 			data: pressedPage,
 		};
-		expect(processFrontData(frontConfigWithData)).toEqual(['1', '2', '3']);
+		expect(
+			processFrontData(frontConfigWithData, collectionMismatchAlarm),
+		).toEqual(['1', '2', '3']);
 	});
 
-	it('should match a collection by name even if capitalisation differs', () => {
+	it('should match a collection by id even if capitalisation differs', () => {
 		const frontConfigWithData = {
-			collectionIndexes: [],
-			collectionNames: ['My Container'],
 			sectionContentURL: 'sectionContentURL',
 			data: pressedPage,
+			collectionIds: [
+				{
+					id: 'DEF',
+					name: 'my container',
+				},
+			],
 		};
-		expect(processFrontData(frontConfigWithData)).toEqual(['3']);
+		expect(
+			processFrontData(frontConfigWithData, collectionMismatchAlarm),
+		).toEqual(['3']);
 	});
 
 	it('should ignore unmatched collections', () => {
 		const frontConfigWithData = {
-			collectionIndexes: [],
-			collectionNames: ['not a match'],
 			sectionContentURL: 'sectionContentURL',
 			data: pressedPage,
+			collectionIds: [
+				{
+					id: 'non-existent-colection-id',
+					name: 'n/a',
+				},
+			],
 		};
-		expect(processFrontData(frontConfigWithData)).toEqual([]);
+		expect(
+			processFrontData(frontConfigWithData, collectionMismatchAlarm),
+		).toEqual([]);
+	});
+
+	it('should call the alarm function when a collection is not found', () => {
+		let alarmHasBeenCalled = false;
+
+		function alarmFunction() {
+			alarmHasBeenCalled = true;
+		}
+
+		const frontConfigWithData = {
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPage,
+			collectionIds: [
+				{
+					id: 'def',
+					name: 'My Container',
+				},
+				{
+					id: 'non-existent-colection-id',
+					name: 'n/a',
+				},
+			],
+		};
+		processFrontData(frontConfigWithData, alarmFunction);
+		expect(alarmHasBeenCalled).toEqual(true);
 	});
 });

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -23,21 +23,34 @@ export interface SectionConfig {
 	capiSources: string[];
 }
 
+export interface CollectionIdentifiers {
+	/**
+	 * The unique id of a collection as it occurs in the pressed front json.
+	 * Usually this is a 'UUID'-style string (e.g.
+	 * `"ffe273ef-8e3e-43eb-a96a-fa528e0f57d1/"`), but occasionally it will be a
+	 * more human readable string (e.g. `"uk-alpha")
+	 */
+	id: string;
+	/**
+	 Collection names are used to identify a collection in the pressed front
+	 page via its `displayName` property. This is used here for two purposes:
+
+	 1. To provide a more human readable way of identifying a collection.
+	 2. We know that a given collection can have its name changed without the id
+	    changing, so if there's a mismatch between the expected collection name
+	    and the actual collection name then this is a signal that we should
+	    review the config to make sure that the id still refers to an
+	    appropriate collection.
+
+	 */
+	name: string;
+}
+
 export interface FrontSource {
 	/**
-	 * The index of the collection as it occurs in the pressed front json.
-	 *
-	 * Notes:
-	 * - not all collections are displayed on the web version of the front page,
-	 *  so indexes should not be inferred from the position of a collection on the web
-	 * - collection indexes start at 0, rather than 1,
+	 * Ids of the collections from the front json that we want to extract articles from.
 	 */
-	collectionIndexes: number[];
-	/**
-	 * Collection names are used to identify a collection in the pressed front page
-	 * via its `displayName` property.
-	 */
-	collectionNames: string[];
+	collectionIds: CollectionIdentifiers[];
 	/**
 	 * Path to the 'lite' json version of a pressed front page.
 	 * @example `"http://api.nextgen.guardianapps.co.uk/science/lite.json"`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Refactors the fronts config to specify collections by `id` instead of name or index. We expect the `id` to be more stable over time than name and (especially) index. I've continued to include the expected display name of the collection in the config, though, to preserve a record of the intended target. This will allow us to log when a collection name changes, which could be used as a prompt to check that the collection is still appropriate for inclusion.

## How to test

- [x] Deploy to CODE and manually trigger the lambdas; compare the output with the existing prod lambdas.

## How can we measure success?

This should allow us to add an alarm when an expected collection id is not found on a front page. This will allow incremental review of the configs as and when there's a breaking change in the fronts. This should mean that we fix issues earlier, and will also hopefully be more efficient than periodic general reviews where context may be lacking.

