### PR TITLE
Custom monitoring for scheduled lambda

### DIFF
--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -10,13 +10,13 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
-      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
-      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
-      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
-      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -873,99 +873,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "pressreaderAUSErrorPercentageAlarmForLambda163DFFB6": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-AUS-TEST-ErrorAlarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 45,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "pressreaderAUS6886FE30",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUS6886FE30",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUS6886FE30",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "pressreaderAUSServiceRole2C141000": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1149,6 +1056,99 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "pressreaderAUSTESTScheduledLambdaErrorAlarm30CE0D3C": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-AUS-TEST-ScheduledLambdaErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderAUS6886FE30",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUS6886FE30",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUS6886FE30",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "pressreaderAUSold903A9CEE": {
       "DependsOn": [
         "pressreaderAUSoldServiceRoleDefaultPolicy820D82A8",
@@ -1259,99 +1259,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Timeout": 300,
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "pressreaderAUSoldErrorPercentageAlarmForLambdaACAD7657": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-AUS-old-TEST-ErrorAlarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 45,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "pressreaderAUSold903A9CEE",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUSold903A9CEE",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderAUSold903A9CEE",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "pressreaderAUSoldServiceRoleDefaultPolicy820D82A8": {
       "Properties": {
@@ -1533,6 +1440,99 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "pressreaderAUSoldTESTScheduledLambdaErrorAlarmED115CE8": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-AUS-old-TEST-ScheduledLambdaErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderAUSold903A9CEE",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSold903A9CEE",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderAUSold903A9CEE",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "pressreaderAUSoldpressreaderAUSoldrate15minutes071CE71C7": {
       "Properties": {
@@ -1721,99 +1721,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "pressreaderUSErrorPercentageAlarmForLambda42ECEB9A": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-US-TEST-ErrorAlarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 45,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "pressreaderUS45258E18",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderUS45258E18",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "pressreaderUS45258E18",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "pressreaderUSServiceRoleB97C448A": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1997,7 +1904,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pressreaderUSoldErrorPercentageAlarmForLambdaF82C074F": {
+    "pressreaderUSTESTScheduledLambdaErrorAlarm5159CCA4": {
       "Properties": {
         "ActionsEnabled": true,
         "AlarmActions": [
@@ -2025,9 +1932,9 @@ exports[`The PressReader stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
-        "AlarmName": "pressreader-US-old-TEST-ErrorAlarm",
+        "AlarmName": "pressreader-US-TEST-ScheduledLambdaErrorAlarm",
         "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 45,
+        "EvaluationPeriods": 2,
         "Metrics": [
           {
             "Expression": "100*m1/m2",
@@ -2038,7 +1945,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 [
                   "Error % of ",
                   {
-                    "Ref": "pressreaderUSoldF30522C8",
+                    "Ref": "pressreaderUS45258E18",
                   },
                 ],
               ],
@@ -2052,14 +1959,14 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                   {
                     "Name": "FunctionName",
                     "Value": {
-                      "Ref": "pressreaderUSoldF30522C8",
+                      "Ref": "pressreaderUS45258E18",
                     },
                   },
                 ],
                 "MetricName": "Errors",
                 "Namespace": "AWS/Lambda",
               },
-              "Period": 60,
+              "Period": 900,
               "Stat": "Sum",
             },
             "ReturnData": false,
@@ -2072,14 +1979,14 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                   {
                     "Name": "FunctionName",
                     "Value": {
-                      "Ref": "pressreaderUSoldF30522C8",
+                      "Ref": "pressreaderUS45258E18",
                     },
                   },
                 ],
                 "MetricName": "Invocations",
                 "Namespace": "AWS/Lambda",
               },
-              "Period": 60,
+              "Period": 900,
               "Stat": "Sum",
             },
             "ReturnData": false,
@@ -2381,6 +2288,99 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "pressreaderUSoldTESTScheduledLambdaErrorAlarm71AD4248": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderemailalarmtopic5E019B49",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "Triggers if there are errors from pressreader on TEST",
+        "AlarmName": "pressreader-US-old-TEST-ScheduledLambdaErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 2,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "pressreaderUSoldF30522C8",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUSoldF30522C8",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "pressreaderUSoldF30522C8",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "pressreaderUSoldpressreaderUSoldrate15minutes079876FA8": {
       "Properties": {

--- a/packages/cdk/lib/constructs/GuLambdaErrorPercentageAlarm.ts
+++ b/packages/cdk/lib/constructs/GuLambdaErrorPercentageAlarm.ts
@@ -1,0 +1,58 @@
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch/alarm';
+import type { GuAlarmProps } from '@guardian/cdk/lib/constructs/cloudwatch/alarm';
+import type { GuLambdaErrorPercentageMonitoringProps } from '@guardian/cdk/lib/constructs/cloudwatch/lambda-alarms';
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda';
+import type { Duration } from 'aws-cdk-lib';
+import {
+	ComparisonOperator,
+	MathExpression,
+	TreatMissingData,
+} from 'aws-cdk-lib/aws-cloudwatch';
+
+interface GuScheduledLambdaErrorPercentageMonitoringProps
+	extends GuLambdaErrorPercentageMonitoringProps {
+	lengthOfEvaluationPeriod?: Duration;
+	numberOfEvaluationPeriodsAboveThresholdBeforeAlarm?: number;
+}
+
+interface GuScheduledLambdaAlarmProps
+	extends GuScheduledLambdaErrorPercentageMonitoringProps {
+	lambda: GuScheduledLambda;
+	lengthOfEvaluationPeriod?: Duration;
+	numberOfEvaluationPeriodsAboveThresholdBeforeAlarm?: number;
+}
+
+/**
+ * Creates an alarm which is triggered whenever the error percentage specified is exceeded
+ * For scheduled lambdas we must take into account how often they are run in order to
+ * choose when it is appropriate to trigger an alarm.
+ */
+export class GuScheduledLambdaErrorPercentageAlarm extends GuAlarm {
+	constructor(scope: GuStack, id: string, props: GuScheduledLambdaAlarmProps) {
+		const mathExpression = new MathExpression({
+			expression: '100*m1/m2',
+			usingMetrics: {
+				m1: props.lambda.metricErrors(),
+				m2: props.lambda.metricInvocations(),
+			},
+			label: `Error % of ${props.lambda.functionName}`,
+			period: props.lengthOfEvaluationPeriod,
+		});
+		const defaultAlarmName = `High error % from ${props.lambda.functionName} lambda in ${scope.stage}`;
+		const defaultDescription = `${props.lambda.functionName} exceeded ${props.toleratedErrorPercentage}% error rate`;
+		const alarmProps: GuAlarmProps = {
+			...props,
+			app: props.lambda.app,
+			metric: mathExpression,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
+			threshold: props.toleratedErrorPercentage,
+			comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+			evaluationPeriods:
+				props.numberOfEvaluationPeriodsAboveThresholdBeforeAlarm ?? 1,
+			alarmName: props.alarmName ?? defaultAlarmName,
+			alarmDescription: props.alarmDescription ?? defaultDescription,
+		};
+		super(scope, id, alarmProps);
+	}
+}


### PR DESCRIPTION
## What does this change?

This change updates the `GuLambdaErrorPercentageAlarm` construct to take into account the error monitoring requirements of scheduled lambdas.

`GuLambdaAlarmProps` is updated to include `lengthOfEvaluationPeriod` and `numberOfEvaluationPeriodsAboveThresholdBeforeAlarm` so that alarms can be set which take into account the cadence at which a scheduled lambda runs.

```ts
interface GuLambdaAlarmProps extends GuLambdaErrorPercentageMonitoringProps {
	lambda: GuLambdaFunction;
	lengthOfEvaluationPeriod?: Duration;
	numberOfEvaluationPeriodsAboveThresholdBeforeAlarm?: number;
}
```

For example, in this case for a lambda that runs every 15 minutes we want to know if it fails on twice concurrent runs, we would set:

```ts
const alarmProps = {
        toleratedErrorPercentage: 1,
	lengthOfEvaluationPeriod: Duration.minutes(15),
        numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 2,
}
```

## How to test

- [X] Deploy this change into production, manually trigger 2 alarm events within 15 minutes, observe alarm goes off.

<img width="938" alt="Screenshot 2023-06-23 at 09 28 13" src="https://github.com/guardian/pressreader/assets/953792/fabc6f62-df73-4645-9344-2aeb0bb3901e">

<img width="935" alt="Screenshot 2023-06-23 at 09 53 13" src="https://github.com/guardian/pressreader/assets/953792/265ed29a-2251-4b6f-a53f-450f239ae1c5">

## How can we measure success?

We are notified of real errors!