### PR TITLE
Wire up collection lookup failure alarm

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,3 +29,5 @@ There is further documentation on [how the configuration affects what is publish
 Lambda logs can be viewed using the [`app: pressreader` filter in Kibana on logs.gutools.co.uk](https://logs.gutools.co.uk/s/newsroom-resilience/goto/8f38a860-fb94-11ed-a6e5-05ce52e0b77b).
 
 Monitoring on lambda errors is configured in [`./cdk/lib/pressreader.ts`](../packages/cdk/lib/pressreader.ts#L141), and will send alarm events to `newsroom.resilience+alerts@guardian.co.uk`.
+
+The edition configuration specifies a set of collections on Guardian web fronts that the script extracts stories from. Sometimes these collections are removed or renamed. When the script fails to find an expected collection is will send alarm notifications to `newsroom.resilience+notifications@guardian.co.uk`. These notifications don't include details about the missing collections, but more information can be found by searching the [project logs](https://logs.gutools.co.uk/s/newsroom-resilience/goto/8f38a860-fb94-11ed-a6e5-05ce52e0b77b).

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
             "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -71,8 +70,7 @@
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/crc32c": {
             "version": "3.0.0",
@@ -95,7 +93,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
             "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -103,8 +100,7 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha1-browser": {
             "version": "3.0.0",
@@ -131,7 +127,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
             "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
                 "@aws-crypto/sha256-js": "^3.0.0",
@@ -146,14 +141,12 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
             "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -163,14 +156,12 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
             "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -178,14 +169,12 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-crypto/util": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
             "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -195,8 +184,7 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.337.0",
@@ -218,6 +206,823 @@
             "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.360.0.tgz",
+            "integrity": "sha512-4Vvlq2ahaUWYUs8P0sp+6bqCjiydwszLqwRzqA9dPwRbPtITEwP+tdREAiqVXSRSRv2y5VcmZUMHjixpIpflGg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.360.0",
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/credential-provider-node": "3.360.0",
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/hash-node": "3.357.0",
+                "@aws-sdk/invalid-dependency": "3.357.0",
+                "@aws-sdk/middleware-content-length": "3.357.0",
+                "@aws-sdk/middleware-endpoint": "3.357.0",
+                "@aws-sdk/middleware-host-header": "3.357.0",
+                "@aws-sdk/middleware-logger": "3.357.0",
+                "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                "@aws-sdk/middleware-retry": "3.357.0",
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/middleware-signing": "3.357.0",
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/middleware-user-agent": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.357.0",
+                "@aws-sdk/util-user-agent-node": "3.357.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/util-waiter": "3.357.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/abort-controller": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+            "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sso": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.360.0.tgz",
+            "integrity": "sha512-0f6eG+6XFbDxrma5xxNGg/FJxh/OHC6h8AkfNms9Lv1gBoQSagpcTor+ax0z9F6lypOjaelX6k4DpeKAp4PZeA==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/hash-node": "3.357.0",
+                "@aws-sdk/invalid-dependency": "3.357.0",
+                "@aws-sdk/middleware-content-length": "3.357.0",
+                "@aws-sdk/middleware-endpoint": "3.357.0",
+                "@aws-sdk/middleware-host-header": "3.357.0",
+                "@aws-sdk/middleware-logger": "3.357.0",
+                "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                "@aws-sdk/middleware-retry": "3.357.0",
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/middleware-user-agent": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.357.0",
+                "@aws-sdk/util-user-agent-node": "3.357.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.360.0.tgz",
+            "integrity": "sha512-czIpPt75fS3gH3vgFz76+WTaKcvPxC/DnPuqVyHdihMmP0UuwGPU9jn+Xx9RdUw7Yay3+rJRe3AYgBn4Xb220g==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/hash-node": "3.357.0",
+                "@aws-sdk/invalid-dependency": "3.357.0",
+                "@aws-sdk/middleware-content-length": "3.357.0",
+                "@aws-sdk/middleware-endpoint": "3.357.0",
+                "@aws-sdk/middleware-host-header": "3.357.0",
+                "@aws-sdk/middleware-logger": "3.357.0",
+                "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                "@aws-sdk/middleware-retry": "3.357.0",
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/middleware-user-agent": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.357.0",
+                "@aws-sdk/util-user-agent-node": "3.357.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/client-sts": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.360.0.tgz",
+            "integrity": "sha512-ORRwSdwlSYGHfhQCXKtr1eJeTjI14l5IZRJbRDgXs46y4/GQj/rt/2Q6WGjVMfM1ZRRiEII2/vK7mU7IJcWkFw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/credential-provider-node": "3.360.0",
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/hash-node": "3.357.0",
+                "@aws-sdk/invalid-dependency": "3.357.0",
+                "@aws-sdk/middleware-content-length": "3.357.0",
+                "@aws-sdk/middleware-endpoint": "3.357.0",
+                "@aws-sdk/middleware-host-header": "3.357.0",
+                "@aws-sdk/middleware-logger": "3.357.0",
+                "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                "@aws-sdk/middleware-retry": "3.357.0",
+                "@aws-sdk/middleware-sdk-sts": "3.357.0",
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/middleware-signing": "3.357.0",
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/middleware-user-agent": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.357.0",
+                "@aws-sdk/util-user-agent-node": "3.357.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/config-resolver": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
+            "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-config-provider": "3.310.0",
+                "@aws-sdk/util-middleware": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
+            "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
+            "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.360.0.tgz",
+            "integrity": "sha512-pWuLTq+yjSFssPGhDJ8oxvZsu7/F1KissGRt65G4qrfxHhoiMRcLF1GtFJueDQpitZ1i3mZXHVn/OSv4LPQ1Lw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.357.0",
+                "@aws-sdk/credential-provider-imds": "3.357.0",
+                "@aws-sdk/credential-provider-process": "3.357.0",
+                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-web-identity": "3.357.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.360.0.tgz",
+            "integrity": "sha512-j4Lu5vXkdzz/L6fGKKxnL0vcwAGHlwFHjTg9nRagMn1lvaVjtktXeM30duHTBQq9i+ejdFxpVNWYrmHGaWPNdg==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.357.0",
+                "@aws-sdk/credential-provider-imds": "3.357.0",
+                "@aws-sdk/credential-provider-ini": "3.360.0",
+                "@aws-sdk/credential-provider-process": "3.357.0",
+                "@aws-sdk/credential-provider-sso": "3.360.0",
+                "@aws-sdk/credential-provider-web-identity": "3.357.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
+            "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.360.0.tgz",
+            "integrity": "sha512-kW0FR8AbMQrJxADxIqYSjHVN2RXwHmA5DzogYm1AjOkYRMN9JHDVOMQP2K2M6FCynZqTYsKW5lzjPOjS0fu8Dw==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.360.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/token-providers": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
+            "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/eventstream-codec": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+            "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+            "dependencies": {
+                "@aws-crypto/crc32": "3.0.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+            "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/querystring-builder": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/hash-node": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+            "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
+            "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
+            "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-endpoint": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
+            "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
+            "dependencies": {
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-middleware": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
+            "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
+            "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
+            "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
+            "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/service-error-classification": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-middleware": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "tslib": "^2.5.0",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
+            "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
+            "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
+            "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/signature-v4": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-middleware": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
+            "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
+            "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
+            "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+            "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.357.0",
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/querystring-builder": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/property-provider": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
+            "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/protocol-http": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+            "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+            "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
+            "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
+            "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
+            "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/signature-v4": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+            "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
+            "dependencies": {
+                "@aws-sdk/eventstream-codec": "3.357.0",
+                "@aws-sdk/is-array-buffer": "3.310.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-middleware": "3.357.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/smithy-client": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
+            "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-stream": "3.360.0",
+                "@smithy/types": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/token-providers": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.360.0.tgz",
+            "integrity": "sha512-gtnCmn2NL7uSwadqQPeU74Wo7Wf1NMJtui+KSWPYpc3joRZqIYj0kL5w0IT2S9tPQwCFerWVfhkvRkSGJ4nZ/g==",
+            "dependencies": {
+                "@aws-sdk/client-sso-oidc": "3.360.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/types": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/url-parser": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
+            "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
+            "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
+            "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/credential-provider-imds": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/property-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+            "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-middleware": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+            "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-retry": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
+            "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
+            "dependencies": {
+                "@aws-sdk/service-error-classification": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
+            "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
+            "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/util-waiter": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
+            "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/fast-xml-parser": {
+            "version": "4.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "funding": [
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@aws-sdk/client-s3": {
@@ -745,7 +1550,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
             "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1203,7 +2007,6 @@
             "version": "3.337.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.337.0.tgz",
             "integrity": "sha512-yR7e9iWMabUfNWkpQs05QXXBXGwp5cunkzVNeDvcAKgaxVVD2n8wY9Iocl324GvXMplJcnND9l0DvizkTak3yQ==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1238,7 +2041,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
             "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
@@ -1251,7 +2053,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
             "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             }
@@ -1260,7 +2061,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
             "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1272,7 +2072,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
             "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.310.0",
                 "tslib": "^2.5.0"
@@ -1285,7 +2084,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
             "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1342,7 +2140,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
             "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1354,7 +2151,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
             "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1387,6 +2183,24 @@
                 "node": ">= 14.0.0"
             }
         },
+        "node_modules/@aws-sdk/util-stream": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
+            "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
+            "dependencies": {
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/util-stream-browser": {
             "version": "3.337.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.337.0.tgz",
@@ -1416,11 +2230,85 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/abort-controller": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+            "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+            "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/querystring-builder": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "tslib": "^2.5.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+            "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.357.0",
+                "@aws-sdk/protocol-http": "3.357.0",
+                "@aws-sdk/querystring-builder": "3.357.0",
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/protocol-http": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+            "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+            "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-uri-escape": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-stream/node_modules/@aws-sdk/types": {
+            "version": "3.357.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+            "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@aws-sdk/util-uri-escape": {
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
             "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -1465,7 +2353,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
             "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
@@ -1478,7 +2365,6 @@
             "version": "3.259.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -2916,7 +3802,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
             "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
-            "dev": true,
             "dependencies": {
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
@@ -2929,7 +3814,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
             "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
-            "dev": true,
             "dependencies": {
                 "tslib": "^2.5.0"
             },
@@ -3606,13 +4490,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0"
         },
         "node_modules/aws-cdk-lib/node_modules/ajv": {
             "version": "8.12.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3628,7 +4512,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3637,7 +4521,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3652,7 +4536,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/astral-regex": {
             "version": "2.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3661,7 +4545,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/at-least-node": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -3670,13 +4554,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/balanced-match": {
             "version": "1.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3686,7 +4570,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/case": {
             "version": "1.6.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "(MIT OR GPL-3.0-or-later)",
             "engines": {
@@ -3695,7 +4579,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/color-convert": {
             "version": "2.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3707,31 +4591,31 @@
         },
         "node_modules/aws-cdk-lib/node_modules/color-name": {
             "version": "1.1.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/concat-map": {
             "version": "0.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/fs-extra": {
             "version": "9.1.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3746,13 +4630,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
             "version": "4.2.10",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/ignore": {
             "version": "5.2.4",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3761,7 +4645,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3770,13 +4654,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/jsonfile": {
             "version": "6.1.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3788,7 +4672,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/jsonschema": {
             "version": "1.4.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3797,13 +4681,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/aws-cdk-lib/node_modules/lru-cache": {
             "version": "6.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3815,7 +4699,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/minimatch": {
             "version": "3.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3827,7 +4711,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/punycode": {
             "version": "2.3.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3836,7 +4720,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/require-from-string": {
             "version": "2.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3845,7 +4729,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/semver": {
             "version": "7.3.8",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -3860,7 +4744,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
             "version": "4.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3877,7 +4761,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/string-width": {
             "version": "4.2.3",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3891,7 +4775,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -3903,7 +4787,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/table": {
             "version": "6.8.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -3919,7 +4803,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/universalify": {
             "version": "2.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -3928,7 +4812,7 @@
         },
         "node_modules/aws-cdk-lib/node_modules/uri-js": {
             "version": "4.4.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3937,13 +4821,13 @@
         },
         "node_modules/aws-cdk-lib/node_modules/yallist": {
             "version": "4.0.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/aws-cdk-lib/node_modules/yaml": {
             "version": "1.10.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -4123,8 +5007,7 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "dev": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/bplist-parser": {
             "version": "0.2.0",
@@ -9144,8 +10027,7 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-            "dev": true
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -9486,8 +10368,7 @@
         "node_modules/tslib": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
-            "dev": true
+            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -9952,6 +10833,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@aws-sdk/client-cloudwatch": "3.360.0",
                 "axios": "1.4.0",
                 "ts-node-dev": "^2.0.0"
             },
@@ -10001,7 +10883,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
             "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -10011,8 +10892,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10039,7 +10919,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
             "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -10047,8 +10926,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10079,7 +10957,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
             "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^3.0.0",
                 "@aws-crypto/sha256-js": "^3.0.0",
@@ -10094,8 +10971,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10103,7 +10979,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
             "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^3.0.0",
                 "@aws-sdk/types": "^3.222.0",
@@ -10113,8 +10988,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10122,7 +10996,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
             "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -10130,8 +11003,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10139,7 +11011,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
             "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -10149,8 +11020,7 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -10171,6 +11041,669 @@
             "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
+            }
+        },
+        "@aws-sdk/client-cloudwatch": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.360.0.tgz",
+            "integrity": "sha512-4Vvlq2ahaUWYUs8P0sp+6bqCjiydwszLqwRzqA9dPwRbPtITEwP+tdREAiqVXSRSRv2y5VcmZUMHjixpIpflGg==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "3.0.0",
+                "@aws-crypto/sha256-js": "3.0.0",
+                "@aws-sdk/client-sts": "3.360.0",
+                "@aws-sdk/config-resolver": "3.357.0",
+                "@aws-sdk/credential-provider-node": "3.360.0",
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/hash-node": "3.357.0",
+                "@aws-sdk/invalid-dependency": "3.357.0",
+                "@aws-sdk/middleware-content-length": "3.357.0",
+                "@aws-sdk/middleware-endpoint": "3.357.0",
+                "@aws-sdk/middleware-host-header": "3.357.0",
+                "@aws-sdk/middleware-logger": "3.357.0",
+                "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                "@aws-sdk/middleware-retry": "3.357.0",
+                "@aws-sdk/middleware-serde": "3.357.0",
+                "@aws-sdk/middleware-signing": "3.357.0",
+                "@aws-sdk/middleware-stack": "3.357.0",
+                "@aws-sdk/middleware-user-agent": "3.357.0",
+                "@aws-sdk/node-config-provider": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/smithy-client": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/url-parser": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-body-length-browser": "3.310.0",
+                "@aws-sdk/util-body-length-node": "3.310.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                "@aws-sdk/util-endpoints": "3.357.0",
+                "@aws-sdk/util-retry": "3.357.0",
+                "@aws-sdk/util-user-agent-browser": "3.357.0",
+                "@aws-sdk/util-user-agent-node": "3.357.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "@aws-sdk/util-waiter": "3.357.0",
+                "@smithy/protocol-http": "^1.0.1",
+                "@smithy/types": "^1.0.0",
+                "fast-xml-parser": "4.2.5",
+                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@aws-sdk/abort-controller": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+                    "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/client-sso": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.360.0.tgz",
+                    "integrity": "sha512-0f6eG+6XFbDxrma5xxNGg/FJxh/OHC6h8AkfNms9Lv1gBoQSagpcTor+ax0z9F6lypOjaelX6k4DpeKAp4PZeA==",
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "3.0.0",
+                        "@aws-crypto/sha256-js": "3.0.0",
+                        "@aws-sdk/config-resolver": "3.357.0",
+                        "@aws-sdk/fetch-http-handler": "3.357.0",
+                        "@aws-sdk/hash-node": "3.357.0",
+                        "@aws-sdk/invalid-dependency": "3.357.0",
+                        "@aws-sdk/middleware-content-length": "3.357.0",
+                        "@aws-sdk/middleware-endpoint": "3.357.0",
+                        "@aws-sdk/middleware-host-header": "3.357.0",
+                        "@aws-sdk/middleware-logger": "3.357.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                        "@aws-sdk/middleware-retry": "3.357.0",
+                        "@aws-sdk/middleware-serde": "3.357.0",
+                        "@aws-sdk/middleware-stack": "3.357.0",
+                        "@aws-sdk/middleware-user-agent": "3.357.0",
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/node-http-handler": "3.360.0",
+                        "@aws-sdk/smithy-client": "3.360.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/url-parser": "3.357.0",
+                        "@aws-sdk/util-base64": "3.310.0",
+                        "@aws-sdk/util-body-length-browser": "3.310.0",
+                        "@aws-sdk/util-body-length-node": "3.310.0",
+                        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                        "@aws-sdk/util-endpoints": "3.357.0",
+                        "@aws-sdk/util-retry": "3.357.0",
+                        "@aws-sdk/util-user-agent-browser": "3.357.0",
+                        "@aws-sdk/util-user-agent-node": "3.357.0",
+                        "@aws-sdk/util-utf8": "3.310.0",
+                        "@smithy/protocol-http": "^1.0.1",
+                        "@smithy/types": "^1.0.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/client-sso-oidc": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.360.0.tgz",
+                    "integrity": "sha512-czIpPt75fS3gH3vgFz76+WTaKcvPxC/DnPuqVyHdihMmP0UuwGPU9jn+Xx9RdUw7Yay3+rJRe3AYgBn4Xb220g==",
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "3.0.0",
+                        "@aws-crypto/sha256-js": "3.0.0",
+                        "@aws-sdk/config-resolver": "3.357.0",
+                        "@aws-sdk/fetch-http-handler": "3.357.0",
+                        "@aws-sdk/hash-node": "3.357.0",
+                        "@aws-sdk/invalid-dependency": "3.357.0",
+                        "@aws-sdk/middleware-content-length": "3.357.0",
+                        "@aws-sdk/middleware-endpoint": "3.357.0",
+                        "@aws-sdk/middleware-host-header": "3.357.0",
+                        "@aws-sdk/middleware-logger": "3.357.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                        "@aws-sdk/middleware-retry": "3.357.0",
+                        "@aws-sdk/middleware-serde": "3.357.0",
+                        "@aws-sdk/middleware-stack": "3.357.0",
+                        "@aws-sdk/middleware-user-agent": "3.357.0",
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/node-http-handler": "3.360.0",
+                        "@aws-sdk/smithy-client": "3.360.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/url-parser": "3.357.0",
+                        "@aws-sdk/util-base64": "3.310.0",
+                        "@aws-sdk/util-body-length-browser": "3.310.0",
+                        "@aws-sdk/util-body-length-node": "3.310.0",
+                        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                        "@aws-sdk/util-endpoints": "3.357.0",
+                        "@aws-sdk/util-retry": "3.357.0",
+                        "@aws-sdk/util-user-agent-browser": "3.357.0",
+                        "@aws-sdk/util-user-agent-node": "3.357.0",
+                        "@aws-sdk/util-utf8": "3.310.0",
+                        "@smithy/protocol-http": "^1.0.1",
+                        "@smithy/types": "^1.0.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/client-sts": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.360.0.tgz",
+                    "integrity": "sha512-ORRwSdwlSYGHfhQCXKtr1eJeTjI14l5IZRJbRDgXs46y4/GQj/rt/2Q6WGjVMfM1ZRRiEII2/vK7mU7IJcWkFw==",
+                    "requires": {
+                        "@aws-crypto/sha256-browser": "3.0.0",
+                        "@aws-crypto/sha256-js": "3.0.0",
+                        "@aws-sdk/config-resolver": "3.357.0",
+                        "@aws-sdk/credential-provider-node": "3.360.0",
+                        "@aws-sdk/fetch-http-handler": "3.357.0",
+                        "@aws-sdk/hash-node": "3.357.0",
+                        "@aws-sdk/invalid-dependency": "3.357.0",
+                        "@aws-sdk/middleware-content-length": "3.357.0",
+                        "@aws-sdk/middleware-endpoint": "3.357.0",
+                        "@aws-sdk/middleware-host-header": "3.357.0",
+                        "@aws-sdk/middleware-logger": "3.357.0",
+                        "@aws-sdk/middleware-recursion-detection": "3.357.0",
+                        "@aws-sdk/middleware-retry": "3.357.0",
+                        "@aws-sdk/middleware-sdk-sts": "3.357.0",
+                        "@aws-sdk/middleware-serde": "3.357.0",
+                        "@aws-sdk/middleware-signing": "3.357.0",
+                        "@aws-sdk/middleware-stack": "3.357.0",
+                        "@aws-sdk/middleware-user-agent": "3.357.0",
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/node-http-handler": "3.360.0",
+                        "@aws-sdk/smithy-client": "3.360.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/url-parser": "3.357.0",
+                        "@aws-sdk/util-base64": "3.310.0",
+                        "@aws-sdk/util-body-length-browser": "3.310.0",
+                        "@aws-sdk/util-body-length-node": "3.310.0",
+                        "@aws-sdk/util-defaults-mode-browser": "3.360.0",
+                        "@aws-sdk/util-defaults-mode-node": "3.360.0",
+                        "@aws-sdk/util-endpoints": "3.357.0",
+                        "@aws-sdk/util-retry": "3.357.0",
+                        "@aws-sdk/util-user-agent-browser": "3.357.0",
+                        "@aws-sdk/util-user-agent-node": "3.357.0",
+                        "@aws-sdk/util-utf8": "3.310.0",
+                        "@smithy/protocol-http": "^1.0.1",
+                        "@smithy/types": "^1.0.0",
+                        "fast-xml-parser": "4.2.5",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/config-resolver": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.357.0.tgz",
+                    "integrity": "sha512-cukfg0nX7Tzx/xFyH5F4Eyb8DA1ITCGtSQv4vnEjgUop+bkzckuGLKEeBcBhyZY+aw+2C9CVwIHwIMhRm0ul5w==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-config-provider": "3.310.0",
+                        "@aws-sdk/util-middleware": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-env": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.357.0.tgz",
+                    "integrity": "sha512-UOecwfqvXgJVqhfWSZ2S44v2Nq2oceW0PQVQp0JAa9opc2rxSVIfyOhPr0yMoPmpyNcP22rgeg6ce70KULYwiA==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-imds": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.357.0.tgz",
+                    "integrity": "sha512-upw/bfsl7/WydT6gM0lBuR4Ipp4fzYm/E3ObFr0Mg5OkgVPt5ZJE+eeFTvwCpDdBSTKs4JfrK6/iEK8A23Q1jQ==",
+                    "requires": {
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/url-parser": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-ini": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.360.0.tgz",
+                    "integrity": "sha512-pWuLTq+yjSFssPGhDJ8oxvZsu7/F1KissGRt65G4qrfxHhoiMRcLF1GtFJueDQpitZ1i3mZXHVn/OSv4LPQ1Lw==",
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.357.0",
+                        "@aws-sdk/credential-provider-imds": "3.357.0",
+                        "@aws-sdk/credential-provider-process": "3.357.0",
+                        "@aws-sdk/credential-provider-sso": "3.360.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-node": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.360.0.tgz",
+                    "integrity": "sha512-j4Lu5vXkdzz/L6fGKKxnL0vcwAGHlwFHjTg9nRagMn1lvaVjtktXeM30duHTBQq9i+ejdFxpVNWYrmHGaWPNdg==",
+                    "requires": {
+                        "@aws-sdk/credential-provider-env": "3.357.0",
+                        "@aws-sdk/credential-provider-imds": "3.357.0",
+                        "@aws-sdk/credential-provider-ini": "3.360.0",
+                        "@aws-sdk/credential-provider-process": "3.357.0",
+                        "@aws-sdk/credential-provider-sso": "3.360.0",
+                        "@aws-sdk/credential-provider-web-identity": "3.357.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-process": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.357.0.tgz",
+                    "integrity": "sha512-qFWWilFPsc2hR7O0KIhwcE78w+pVIK+uQR6MQMfdRyxUndgiuCorJwVjedc3yZtmnoELHF34j+m8whTBXv9E7Q==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-sso": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.360.0.tgz",
+                    "integrity": "sha512-kW0FR8AbMQrJxADxIqYSjHVN2RXwHmA5DzogYm1AjOkYRMN9JHDVOMQP2K2M6FCynZqTYsKW5lzjPOjS0fu8Dw==",
+                    "requires": {
+                        "@aws-sdk/client-sso": "3.360.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/token-providers": "3.360.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/credential-provider-web-identity": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.357.0.tgz",
+                    "integrity": "sha512-0KRRAFrXy5HJe2vqnCWCoCS+fQw7IoIj3KQsuURJMW4F+ifisxCgEsh3brJ2LQlN4ElWTRJhlrDHNZ/pd61D4w==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/eventstream-codec": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.357.0.tgz",
+                    "integrity": "sha512-bqenTHG6GH6aCk/Il+ooWXVVAZuc8lOgVEy9bE2hI49oVqT8zSuXxQB+w1WWyZoAOPcelsjayB1wfPub8VDBxQ==",
+                    "requires": {
+                        "@aws-crypto/crc32": "3.0.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-hex-encoding": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/fetch-http-handler": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+                    "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/querystring-builder": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-base64": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/hash-node": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.357.0.tgz",
+                    "integrity": "sha512-fq3LS9AxHKb7dTZkm6iM1TrGk6XOTZz96iEZPME1+vjiSEXGWuebHt87q92n+KozVGRypn9MId3lHOPBBjygNQ==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-buffer-from": "3.310.0",
+                        "@aws-sdk/util-utf8": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/invalid-dependency": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.357.0.tgz",
+                    "integrity": "sha512-HnCYZczf0VdyxMVMMxmA3QJAyyPSFbcMtZzgKbxVTWTG7GKpQe0psWZu/7O2Nk31mKg6vEUdiP1FylqLBsgMOA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-content-length": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.357.0.tgz",
+                    "integrity": "sha512-zQOFEyzOXAgN4M54tYNWGxKxnyzY0WwYDTFzh9riJRmxN1hTEKHUKmze4nILIf5rkQmOG4kTf1qmfazjkvZAhw==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-endpoint": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.357.0.tgz",
+                    "integrity": "sha512-ScJi0SL8X/Lyi0Fp5blg0QN/Z6PoRwV/ZJXd8dQkXSznkbSvJHfqPP0xk/w3GcQ1TKsu5YEPfeYy8ejcq+7Pgg==",
+                    "requires": {
+                        "@aws-sdk/middleware-serde": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/url-parser": "3.357.0",
+                        "@aws-sdk/util-middleware": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-host-header": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.357.0.tgz",
+                    "integrity": "sha512-HuGLcP7JP1qJ5wGT9GSlEknDaTSnOzHY4T6IPFuvFjAy3PvY5siQNm6+VRqdVS+n6/kzpL3JP5sAVM3aoxHT6Q==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-logger": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.357.0.tgz",
+                    "integrity": "sha512-dncT3tr+lZ9+duZo52rASgO6AKVwRcsc2/T93gmaYVrJqI6WWAwQ7yML5s72l9ZjQ5LZ+4jjrgtlufavAS0eCg==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-recursion-detection": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.357.0.tgz",
+                    "integrity": "sha512-AXC54IeDS3jC1dbbkYHML4STvBPcKZ4IJTWdjEK1RCOgqXd0Ze1cE1e21wyj1tM6prF03zLyvpBd+3TS++nqfA==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-retry": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.357.0.tgz",
+                    "integrity": "sha512-ZCbXCYv3nglQqwREYxxpclrnR9MYPAnHlLcC8e9PbApqxGnaZdhoywxoqbgqT3hf/RM7kput4vEHDl1fyymcRQ==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/service-error-classification": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-middleware": "3.357.0",
+                        "@aws-sdk/util-retry": "3.357.0",
+                        "tslib": "^2.5.0",
+                        "uuid": "^8.3.2"
+                    }
+                },
+                "@aws-sdk/middleware-sdk-sts": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.357.0.tgz",
+                    "integrity": "sha512-Ng2VjLrPiL02QOcs1qs9jG2boO4Gn+v3VIbOJLG4zXcfbSq55iIWtlmr2ljfw9vP5aLhWtcODfmKHS5Bp+019Q==",
+                    "requires": {
+                        "@aws-sdk/middleware-signing": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-serde": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.357.0.tgz",
+                    "integrity": "sha512-bGI4kYuuEsFjlANbyJLyy4AovETnyf/SukgLOG7Qjbua+ZGuzvRhMsk21mBKKGrnsTO4PmtieJo6xClThGAN8g==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-signing": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.357.0.tgz",
+                    "integrity": "sha512-yB9ewEqI6Fw1OrmKFrUypbCqN5ijk06UGPochybamMuPxxkwMT3bnrm7eezsCA+TZbJyKhpffpyobwuv+xGNrA==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/signature-v4": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-middleware": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-stack": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.357.0.tgz",
+                    "integrity": "sha512-nNV+jfwGwmbOGZujAY/U8AW3EbVlxa9DJDLz3TPp/39o6Vu5KEzHJyDDNreo2k9V/TMvV+nOzHafufgPdagv7w==",
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/middleware-user-agent": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.357.0.tgz",
+                    "integrity": "sha512-M/CsAXjGblZS4rEbMb0Dn9IXbfq4EjVaTHBfvuILU/dKRppWvjnm2lRtqCZ+LIT3ATbAjA3/dY7dWsjxQWwijA==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-endpoints": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/node-config-provider": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.357.0.tgz",
+                    "integrity": "sha512-kwBIzKCaW3UWqLdELhy7TcN8itNMOjbzga530nalFILMvn2IxrkdKQhNgxGBXy6QK6kCOtH6OmcrG3/oZkLwig==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/node-http-handler": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+                    "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
+                    "requires": {
+                        "@aws-sdk/abort-controller": "3.357.0",
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/querystring-builder": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/property-provider": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.357.0.tgz",
+                    "integrity": "sha512-im4W0u8WaYxG7J7ko4Xl3OEzK3Mrm1Rz6/txTGe6hTIHlyUISu1ekOQJXK6XYPqNMn8v1G3BiQREoRXUEJFbHg==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/protocol-http": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+                    "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/querystring-builder": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+                    "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-uri-escape": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/querystring-parser": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.357.0.tgz",
+                    "integrity": "sha512-Svvq+atRNP9s2VxiklcUNgCzmt3T5kfs7X2C+yjmxHvOQTPjLNaNGbfC/vhjOK7aoXw0h+lBac48r5ymx1PbQA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/service-error-classification": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.357.0.tgz",
+                    "integrity": "sha512-VuXeL4g5vKO9HjgCZlxmH8Uv1FcqUSjmbPpQkbNtYIDck6u0qzM0rG+n0/1EjyQbPSr3MhW/pkWs5nx2Nljlyg=="
+                },
+                "@aws-sdk/shared-ini-file-loader": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.357.0.tgz",
+                    "integrity": "sha512-ceyqM4XxQe0Plb/oQAD2t1UOV2Iy4PFe1oAGM8dfJzYrRKu7zvMwru7/WaB3NYq+/mIY6RU+jjhRmjQ3GySVqA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/signature-v4": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.357.0.tgz",
+                    "integrity": "sha512-itt4/Jh9FqnzK30qIjXFBvM4J7zN4S/AAqsRMnaX7U4f/MV+1YxQHmzimpdMnsCXXs2jqFqKVRu6DewxJ3nbxg==",
+                    "requires": {
+                        "@aws-sdk/eventstream-codec": "3.357.0",
+                        "@aws-sdk/is-array-buffer": "3.310.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-hex-encoding": "3.310.0",
+                        "@aws-sdk/util-middleware": "3.357.0",
+                        "@aws-sdk/util-uri-escape": "3.310.0",
+                        "@aws-sdk/util-utf8": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/smithy-client": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.360.0.tgz",
+                    "integrity": "sha512-R7wbT2SkgWNEAxMekOTNcPcvBszabW2+qHjrcelbbVJNjx/2yK+MbpZI4WRSncByQMeeoW+aSUP+JgsbpiOWfw==",
+                    "requires": {
+                        "@aws-sdk/middleware-stack": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-stream": "3.360.0",
+                        "@smithy/types": "^1.0.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/token-providers": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.360.0.tgz",
+                    "integrity": "sha512-gtnCmn2NL7uSwadqQPeU74Wo7Wf1NMJtui+KSWPYpc3joRZqIYj0kL5w0IT2S9tPQwCFerWVfhkvRkSGJ4nZ/g==",
+                    "requires": {
+                        "@aws-sdk/client-sso-oidc": "3.360.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/shared-ini-file-loader": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/url-parser": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.357.0.tgz",
+                    "integrity": "sha512-fAaU6cFsaAba01lCRsRJiYR/LfXvX2wudyEyutBVglE4dWSoSeu3QJNxImIzTBULfbiFhz59++NQ1JUVx88IVg==",
+                    "requires": {
+                        "@aws-sdk/querystring-parser": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-defaults-mode-browser": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.360.0.tgz",
+                    "integrity": "sha512-/GR8VlK9xo1Q5WbVYuNaZ+XfoCFdWNb4z4mpoEgvEgBH4R0GjqiAqLftUA8Ykq1tJuDAKPYVzUNzK8DC0pt7/g==",
+                    "requires": {
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-defaults-mode-node": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.360.0.tgz",
+                    "integrity": "sha512-gR3Ctqpyl7SgStDJ1Jlq6qQDuw/rS9AgbAXx+s3wsmm3fm8lHKkXkDPYVvNDqd6dVXRO6q8MRx00lwkGI4qrpQ==",
+                    "requires": {
+                        "@aws-sdk/config-resolver": "3.357.0",
+                        "@aws-sdk/credential-provider-imds": "3.357.0",
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/property-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-endpoints": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.357.0.tgz",
+                    "integrity": "sha512-XHKyS5JClT9su9hDif715jpZiWHQF9gKZXER8tW0gOizU3R9cyWc9EsJ2BRhFNhi7nt/JF/CLUEc5qDx3ETbUw==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-middleware": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.357.0.tgz",
+                    "integrity": "sha512-pV1krjZs7BdahZBfsCJMatE8kcor7GFsBOWrQgQDm9T0We5b5xPpOO2vxAD0RytBpY8Ky2ELs/+qXMv7l5fWIA==",
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-retry": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.357.0.tgz",
+                    "integrity": "sha512-SUqYJE9msbuOVq+vnUy+t0LH7XuYNFz66dSF8q6tedsbJK4j8tgya0I1Ct3m06ynGrXDJMaj39I7AXCyW9bjtw==",
+                    "requires": {
+                        "@aws-sdk/service-error-classification": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-user-agent-browser": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.357.0.tgz",
+                    "integrity": "sha512-JHaWlNIUkPNvXkqeDOrqFzAlAgdwZK5mZw7FQnCRvf8tdSogpGZSkuyb9Z6rLD9gC40Srbc2nepO1cFpeMsDkA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "bowser": "^2.11.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-user-agent-node": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.357.0.tgz",
+                    "integrity": "sha512-RdpQoaJWQvcS99TVgSbT451iGrlH4qpWUWFA9U1IRhxOSsmC1hz8ME7xc8nci9SREx/ZlfT3ai6LpoAzAtIEMA==",
+                    "requires": {
+                        "@aws-sdk/node-config-provider": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/util-waiter": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.357.0.tgz",
+                    "integrity": "sha512-jQQGA5G8bm0JP5C4U85VzMpkFHdeeT7fOSUncXLG9Sh8Ambzi4XTud8m5/dA7aNJkvPwZeIF9QdgWCOzpkp1xA==",
+                    "requires": {
+                        "@aws-sdk/abort-controller": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "fast-xml-parser": {
+                    "version": "4.2.5",
+                    "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+                    "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+                    "requires": {
+                        "strnum": "^1.0.5"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
             }
         },
         "@aws-sdk/client-s3": {
@@ -10640,7 +12173,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
             "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -10999,7 +12531,6 @@
             "version": "3.337.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.337.0.tgz",
             "integrity": "sha512-yR7e9iWMabUfNWkpQs05QXXBXGwp5cunkzVNeDvcAKgaxVVD2n8wY9Iocl324GvXMplJcnND9l0DvizkTak3yQ==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11028,7 +12559,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
             "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
-            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
@@ -11038,7 +12568,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
             "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11047,7 +12576,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
             "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11056,7 +12584,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
             "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
-            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.310.0",
                 "tslib": "^2.5.0"
@@ -11066,7 +12593,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
             "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11111,7 +12637,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
             "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11120,7 +12645,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
             "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11142,6 +12666,83 @@
             "requires": {
                 "@aws-sdk/service-error-classification": "3.337.0",
                 "tslib": "^2.5.0"
+            }
+        },
+        "@aws-sdk/util-stream": {
+            "version": "3.360.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream/-/util-stream-3.360.0.tgz",
+            "integrity": "sha512-t3naBfNesXwLis29pzSfLx2ifCn2180GiPjRaIsQP14IiVCBOeT1xaU6Dpyk7WeR/jW4cu7wGl+kbeyfNF6QmQ==",
+            "requires": {
+                "@aws-sdk/fetch-http-handler": "3.357.0",
+                "@aws-sdk/node-http-handler": "3.360.0",
+                "@aws-sdk/types": "3.357.0",
+                "@aws-sdk/util-base64": "3.310.0",
+                "@aws-sdk/util-buffer-from": "3.310.0",
+                "@aws-sdk/util-hex-encoding": "3.310.0",
+                "@aws-sdk/util-utf8": "3.310.0",
+                "tslib": "^2.5.0"
+            },
+            "dependencies": {
+                "@aws-sdk/abort-controller": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.357.0.tgz",
+                    "integrity": "sha512-nQYDJon87quPwt2JZJwUN2GFKJnvE5kWb6tZP4xb5biSGUKBqDQo06oYed7yokatCuCMouIXV462aN0fWODtOw==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/fetch-http-handler": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.357.0.tgz",
+                    "integrity": "sha512-5sPloTO8y8fAnS/6/Sfp/aVoL9zuhzkLdWBORNzMazdynVNEzWKWCPZ27RQpgkaCDHiXjqUY4kfuFXAGkvFfDQ==",
+                    "requires": {
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/querystring-builder": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-base64": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/node-http-handler": {
+                    "version": "3.360.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.360.0.tgz",
+                    "integrity": "sha512-oMsXdMmNwHpUbebETO44bq0N4SocEMGfPjYNUTRs8md7ita5fuFd2qFuvf+ZRt6iVcGWluIqmF8DidD+b7d+TA==",
+                    "requires": {
+                        "@aws-sdk/abort-controller": "3.357.0",
+                        "@aws-sdk/protocol-http": "3.357.0",
+                        "@aws-sdk/querystring-builder": "3.357.0",
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/protocol-http": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.357.0.tgz",
+                    "integrity": "sha512-w1JHiI50VEea7duDeAspUiKJmmdIQblvRyjVMOqWA6FIQAyDVuEiPX7/MdQr0ScxhtRQxHbP0I4MFyl7ctRQvA==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/querystring-builder": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.357.0.tgz",
+                    "integrity": "sha512-aQcicqB6Y2cNaXPPwunz612a01SMiQQPsdz632F/3Lzn0ua82BJKobHOtaiTUlmVJ5Q4/EAeNfwZgL7tTUNtDQ==",
+                    "requires": {
+                        "@aws-sdk/types": "3.357.0",
+                        "@aws-sdk/util-uri-escape": "3.310.0",
+                        "tslib": "^2.5.0"
+                    }
+                },
+                "@aws-sdk/types": {
+                    "version": "3.357.0",
+                    "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.357.0.tgz",
+                    "integrity": "sha512-/riCRaXg3p71BeWnShrai0y0QTdXcouPSM0Cn1olZbzTf7s71aLEewrc96qFrL70XhY4XvnxMpqQh+r43XIL3g==",
+                    "requires": {
+                        "tslib": "^2.5.0"
+                    }
+                }
             }
         },
         "@aws-sdk/util-stream-browser": {
@@ -11174,7 +12775,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
             "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -11205,7 +12805,6 @@
             "version": "3.310.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
             "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
-            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.310.0",
                 "tslib": "^2.5.0"
@@ -11215,7 +12814,6 @@
             "version": "3.259.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
             "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -12327,7 +13925,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
             "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
-            "dev": true,
             "requires": {
                 "@smithy/types": "^1.0.0",
                 "tslib": "^2.5.0"
@@ -12337,7 +13934,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
             "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
-            "dev": true,
             "requires": {
                 "tslib": "^2.5.0"
             }
@@ -12835,12 +14431,12 @@
                 "@balena/dockerignore": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "ajv": {
                     "version": "8.12.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
                         "json-schema-traverse": "^1.0.0",
@@ -12851,12 +14447,12 @@
                 "ansi-regex": {
                     "version": "5.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "4.3.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -12864,22 +14460,22 @@
                 "astral-regex": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "at-least-node": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "balanced-match": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -12888,12 +14484,12 @@
                 "case": {
                     "version": "1.6.3",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "color-convert": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -12901,27 +14497,27 @@
                 "color-name": {
                     "version": "1.1.4",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "fast-deep-equal": {
                     "version": "3.1.3",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "fs-extra": {
                     "version": "9.1.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
@@ -12932,27 +14528,27 @@
                 "graceful-fs": {
                     "version": "4.2.10",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "ignore": {
                     "version": "5.2.4",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "jsonfile": {
                     "version": "6.1.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6",
                         "universalify": "^2.0.0"
@@ -12961,17 +14557,17 @@
                 "jsonschema": {
                     "version": "1.4.1",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "lodash.truncate": {
                     "version": "4.4.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "lru-cache": {
                     "version": "6.0.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "yallist": "^4.0.0"
                     }
@@ -12979,7 +14575,7 @@
                 "minimatch": {
                     "version": "3.1.2",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -12987,17 +14583,17 @@
                 "punycode": {
                     "version": "2.3.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "require-from-string": {
                     "version": "2.0.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "semver": {
                     "version": "7.3.8",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -13005,7 +14601,7 @@
                 "slice-ansi": {
                     "version": "4.0.0",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^4.0.0",
                         "astral-regex": "^2.0.0",
@@ -13015,7 +14611,7 @@
                 "string-width": {
                     "version": "4.2.3",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
@@ -13025,7 +14621,7 @@
                 "strip-ansi": {
                     "version": "6.0.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -13033,7 +14629,7 @@
                 "table": {
                     "version": "6.8.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "ajv": "^8.0.1",
                         "lodash.truncate": "^4.4.2",
@@ -13045,12 +14641,12 @@
                 "universalify": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "uri-js": {
                     "version": "4.4.1",
                     "bundled": true,
-                    "extraneous": true,
+                    "dev": true,
                     "requires": {
                         "punycode": "^2.1.0"
                     }
@@ -13058,12 +14654,12 @@
                 "yallist": {
                     "version": "4.0.0",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 },
                 "yaml": {
                     "version": "1.10.2",
                     "bundled": true,
-                    "extraneous": true
+                    "dev": true
                 }
             }
         },
@@ -13196,8 +14792,7 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-            "dev": true
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "bplist-parser": {
             "version": "0.2.0",
@@ -16229,6 +17824,7 @@
         "pressreader": {
             "version": "file:packages/pressreader",
             "requires": {
+                "@aws-sdk/client-cloudwatch": "3.360.0",
                 "@aws-sdk/client-s3": "^3.337.0",
                 "@aws-sdk/client-secrets-manager": "^3.337.0",
                 "@guardian/content-api-models": "17.6.2",
@@ -16787,8 +18383,7 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-            "dev": true
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "supports-color": {
             "version": "7.2.0",
@@ -17012,8 +18607,7 @@
         "tslib": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
-            "dev": true
+            "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
         },
         "tsutils": {
             "version": "3.21.0",

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -226,7 +226,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
+                    "pressreaderTESTemailnotificationstopic55C74525",
                     "TopicName",
                   ],
                 },
@@ -237,7 +237,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "DatapointsToAlarm": 1,
         "EvaluationPeriods": 1,
-        "MetricName": "CollectionLookupFailure",
+        "MetricName": "CollectionLookupFailure-TEST",
         "Namespace": "AWS/Lambda",
         "Period": 300,
         "Statistic": "Average",
@@ -779,7 +779,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
+                    "pressreaderTESTemailalarmtopicE3E05C64",
                     "TopicName",
                   ],
                 },
@@ -872,7 +872,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
+                    "pressreaderTESTemailalarmtopicE3E05C64",
                     "TopicName",
                   ],
                 },
@@ -1018,7 +1018,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "AUS",
-            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure-TEST",
             "PREFIX_PATH": "data/AUS",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1312,7 +1312,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "AUS",
-            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure-TEST",
             "PREFIX_PATH": "",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1680,7 +1680,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "US",
-            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure-TEST",
             "PREFIX_PATH": "data/US",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -1974,7 +1974,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               ],
             },
             "EDITION_KEY": "US",
-            "FAILURE_METRIC_NAME": "CollectionLookupFailure",
+            "FAILURE_METRIC_NAME": "CollectionLookupFailure-TEST",
             "PREFIX_PATH": "",
             "STACK": "print-production",
             "STAGE": "TEST",
@@ -2270,6 +2270,72 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
+    "pressreaderTESTemailalarmtopicE3E05C64": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "pressreaderTESTemailalarmtopicnewsroomresiliencealertsguardiancouk46957B5A": {
+      "Properties": {
+        "Endpoint": "newsroom.resilience+alerts@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "pressreaderTESTemailalarmtopicE3E05C64",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "pressreaderTESTemailnotificationstopic55C74525": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "pressreaderTESTemailnotificationstopicnewsroomresiliencenotificationsguardiancouk2730C2EB": {
+      "Properties": {
+        "Endpoint": "newsroom.resilience+notifications@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "pressreaderTESTemailnotificationstopic55C74525",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "pressreaderUSTESTScheduledLambdaErrorAlarm5159CCA4": {
       "Properties": {
         "ActionsEnabled": true,
@@ -2289,7 +2355,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
+                    "pressreaderTESTemailalarmtopicE3E05C64",
                     "TopicName",
                   ],
                 },
@@ -2382,7 +2448,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                 ":",
                 {
                   "Fn::GetAtt": [
-                    "pressreaderemailalarmtopic5E019B49",
+                    "pressreaderTESTemailalarmtopicE3E05C64",
                     "TopicName",
                   ],
                 },
@@ -2455,39 +2521,6 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
-    },
-    "pressreaderemailalarmtopic5E019B49": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/pressreader",
-          },
-          {
-            "Key": "Stack",
-            "Value": "print-production",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::SNS::Topic",
-    },
-    "pressreaderemailalarmtopicnewsroomresiliencealertsguardiancoukC7FA91A6": {
-      "Properties": {
-        "Endpoint": "newsroom.resilience+alerts@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": {
-          "Ref": "pressreaderemailalarmtopic5E019B49",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
     },
   },
 }

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -26,6 +26,7 @@
 	},
 	"homepage": "https://github.com/guardian/pressreader#readme",
 	"dependencies": {
+		"@aws-sdk/client-cloudwatch": "3.360.0",
 		"axios": "1.4.0",
 		"ts-node-dev": "^2.0.0"
 	}

--- a/packages/pressreader/src/constants.ts
+++ b/packages/pressreader/src/constants.ts
@@ -1,7 +1,7 @@
 export const awsRegion = process.env.AWS_REGION ?? 'eu-west-1';
 export const bucketName = process.env.BUCKET_NAME ?? 'dev-pressreader';
 export const prefixPath = process.env.PREFIX_PATH ?? '';
-export const failureMetricArn = process.env.FAILURE_METRIC_NAME ?? '';
+export const failureMetricName = process.env.FAILURE_METRIC_NAME ?? '';
 export const editionKey = process.env.EDITION_KEY;
 export const capiSecretLocation =
 	process.env.CAPI_SECRET_LOCATION ??

--- a/packages/pressreader/src/handler.ts
+++ b/packages/pressreader/src/handler.ts
@@ -1,4 +1,5 @@
 import { isEditionKey } from '../../shared-types';
+import { sendCollectionMismatchMetric } from './aws';
 import { editionKey } from './constants';
 import { editionConfigs } from './editionConfigs';
 import { editionProcessor } from './processEdition';
@@ -23,7 +24,7 @@ export const main = async () => {
 			capiKey: capiToken,
 			baseCapiUrl: 'https://content.guardianapis.com',
 		},
-		collectionMismatchAlarm: () => null,
+		collectionMismatchAlarm: sendCollectionMismatchMetric,
 	});
 
 	const data = await processor.run();


### PR DESCRIPTION
## What does this change?

- Separate SNS topic and email subscription for 'alarms' vs 'notifications' (the latter being non-critical).
- Add stage to the topics for both subscriptions, and also to the custom metric for collection lookup failures. This is so that publishing to the metric won't result in alarms for *both* stages; instead it should only alarm for the stage that the metric was published from.
- Pass metric publishing function from the handler to the processing function which has the information needed to trigger the alarm.
- Document this notification in the project README.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE and put some data to the `CollectionLookupFailure-CODE` metric. Check that the notification email is sent to the NR list.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We find out about config issues when they happen and review them incrementally, rather than waiting for someone to complain because so many bugs have accumulated.

## Have we considered potential risks?

If we're getting far too many emails then we should review this method. Using a cloudwatch alarm doesn't allow us to include much useful information about the nature of the issue, so there's also some overhead in having to go to the logs to find out where the config needs updating, but hopefully this won't happen too often.
