### PR TITLE
Add index-based lookup for collections

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -15,6 +15,15 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Headlines',
 						},
+						{
+							lookupType: 'index',
+							/**
+							 * aiming to target the first actual collection on the page, below the hidden
+							 * 'palette styles' collection.  This will often be the same as 'Headlines', but
+							 * headlines might be pushed down if there's a special event.
+							 * */
+							index: 1,
+						},
 					],
 				},
 			],

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -10,7 +10,11 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
-						{ id: 'a22fa7fc-684f-484a-90bf-3f5aa4b711f7', name: 'Headlines' },
+						{
+							id: 'a22fa7fc-684f-484a-90bf-3f5aa4b711f7',
+							lookupType: 'id',
+							name: 'Headlines',
+						},
 					],
 				},
 			],
@@ -26,6 +30,7 @@ export const ausConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: 'ee319aab-a40c-4bc5-a40d-fa8f0b8f2b88',
+							lookupType: 'id',
 							name: 'Australia news',
 						},
 					],
@@ -36,6 +41,7 @@ export const ausConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '5d60fb3d-9bb2-439b-81d4-3bd4d625165a',
+							lookupType: 'id',
 							name: 'Across the country',
 						},
 					],
@@ -53,6 +59,7 @@ export const ausConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '47eb1794-2f5a-490d-a3af-425d88e2d2f2',
+							lookupType: 'id',
 							name: 'Australian politics',
 						},
 					],
@@ -70,9 +77,14 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/international/lite.json',
 					collectionIds: [
-						{ id: '10f21d96-18f6-426f-821b-19df55dfb831', name: 'Headlines' },
+						{
+							id: '10f21d96-18f6-426f-821b-19df55dfb831',
+							lookupType: 'id',
+							name: 'Headlines',
+						},
 						{
 							id: '2c19b8b3-6503-4a3b-8821-9a04898b5243',
+							lookupType: 'id',
 							name: 'Around the world',
 						},
 					],
@@ -94,26 +106,43 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/commentisfree/lite.json',
 					collectionIds: [
-						{ id: '856d1576-46f0-4cbb-af2a-ec83f0eaa9ff', name: 'Columnists' },
+						{
+							id: '856d1576-46f0-4cbb-af2a-ec83f0eaa9ff',
+							lookupType: 'id',
+							name: 'Columnists',
+						},
 						{
 							id: '644f8b13-1b3b-42fd-b4a4-79309849b6f4',
+							lookupType: 'id',
 							name: 'Indigenous Australia',
 						},
-						{ id: 'au/commentisfree/regular-stories', name: 'Opinion' },
+						{
+							id: 'au/commentisfree/regular-stories',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
-						{ id: 'au-alpha/contributors/feature-stories', name: 'Opinion' },
+						{
+							id: 'au-alpha/contributors/feature-stories',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/commentisfree/lite.json',
 					collectionIds: [
-						{ id: 'a3194998-0d92-49a5-aaa2-c3b7cd26bafc', name: 'World view' },
+						{
+							id: 'a3194998-0d92-49a5-aaa2-c3b7cd26bafc',
+							lookupType: 'id',
+							name: 'World view',
+						},
 					],
 				},
 			],
@@ -127,17 +156,31 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/business/lite.json',
 					collectionIds: [
-						{ id: 'c7bc8956-7d55-4968-840b-e23e44f0e18b', name: 'News' },
-						{ id: '0a1173d4-8904-4221-87e6-3f8b22ebc29e', name: 'In depth' },
+						{
+							id: 'c7bc8956-7d55-4968-840b-e23e44f0e18b',
+							lookupType: 'id',
+							name: 'News',
+						},
+						{
+							id: '0a1173d4-8904-4221-87e6-3f8b22ebc29e',
+							lookupType: 'id',
+							name: 'In depth',
+						},
 						{
 							id: 'a7de79b6-5b1b-49d1-8e35-cd3725134c9c',
+							lookupType: 'id',
 							name: 'Greg Jericho',
 						},
 						{
 							id: '02dcfceb-accb-42a4-a998-4cb1c935738f',
+							lookupType: 'id',
 							name: 'Guardian Labs',
 						},
-						{ id: 'a6be553e-2a64-4bb0-9678-b81227eae5e1', name: 'World news' },
+						{
+							id: 'a6be553e-2a64-4bb0-9678-b81227eae5e1',
+							lookupType: 'id',
+							name: 'World news',
+						},
 					],
 				},
 			],
@@ -160,12 +203,29 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/environment/lite.json',
 					collectionIds: [
-						{ id: '586be7cd-1f83-4e71-8ff3-f2610d2d71d9', name: 'Environment' },
-						{ id: 'b2aab4ef-ccab-4a24-bade-419e8222d789', name: 'World news' },
-						{ id: '99b67485-70ef-4f75-be86-15843a8d0207', name: 'Opinion' },
-						{ id: 'bd261fb2-3d6d-465e-92e8-e3bf88b3ee67', name: 'Global view' },
+						{
+							id: '586be7cd-1f83-4e71-8ff3-f2610d2d71d9',
+							lookupType: 'id',
+							name: 'Environment',
+						},
+						{
+							id: 'b2aab4ef-ccab-4a24-bade-419e8222d789',
+							lookupType: 'id',
+							name: 'World news',
+						},
+						{
+							id: '99b67485-70ef-4f75-be86-15843a8d0207',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
+						{
+							id: 'bd261fb2-3d6d-465e-92e8-e3bf88b3ee67',
+							lookupType: 'id',
+							name: 'Global view',
+						},
 						{
 							id: '5561a451-dd53-4114-a957-2c8a18f87132',
+							lookupType: 'id',
 							name: 'Investigations and analysis',
 						},
 					],
@@ -181,9 +241,17 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/science/lite.json',
 					collectionIds: [
-						{ id: 'e9c7-cf23-23b1-363b', name: 'Science' },
-						{ id: 'e7623e60-63fe-4f52-8295-3692ef272beb', name: 'News' },
-						{ id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1', name: 'Key issues' },
+						{ id: 'e9c7-cf23-23b1-363b', lookupType: 'id', name: 'Science' },
+						{
+							id: 'e7623e60-63fe-4f52-8295-3692ef272beb',
+							lookupType: 'id',
+							name: 'News',
+						},
+						{
+							id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1',
+							lookupType: 'id',
+							name: 'Key issues',
+						},
 					],
 				},
 			],
@@ -200,18 +268,32 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/technology/lite.json',
 					collectionIds: [
-						{ id: '6bb3-9f76-43bd-4213', name: 'Technology' },
+						{ id: '6bb3-9f76-43bd-4213', lookupType: 'id', name: 'Technology' },
 						{
 							id: '86be3263-a4db-4bb8-aaa9-7c9662094958',
+							lookupType: 'id',
 							name: 'Australian tech',
 						},
-						{ id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d', name: 'In depth' },
-						{ id: '8185-0956-87b3-126d', name: 'Opinion & analysis' },
+						{
+							id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d',
+							lookupType: 'id',
+							name: 'In depth',
+						},
+						{
+							id: '8185-0956-87b3-126d',
+							lookupType: 'id',
+							name: 'Opinion & analysis',
+						},
 						{
 							id: 'c6a8df3e-7685-4bca-856d-f5b0c59163d0',
+							lookupType: 'id',
 							name: 'Inside Silicon Valley',
 						},
-						{ id: 'cff4aa48-dd86-433f-bc11-eb15abae55fc', name: 'Spotlight' },
+						{
+							id: 'cff4aa48-dd86-433f-bc11-eb15abae55fc',
+							lookupType: 'id',
+							name: 'Spotlight',
+						},
 					],
 				},
 			],
@@ -224,16 +306,27 @@ export const ausConfig: PressReaderEditionConfig = {
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
-					collectionIds: [{ id: 'c45d-318f-896c-3a85', name: 'Sport' }],
+					collectionIds: [
+						{ id: 'c45d-318f-896c-3a85', lookupType: 'id', name: 'Sport' },
+					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/sport/lite.json',
 					collectionIds: [
-						{ id: '0644cd79-4d8b-4d20-a1ed-13f8b7ed4373', name: 'Sport' },
-						{ id: 'f40bb225-86ab-4d85-a98d-bb2ea11fb453', name: 'Features' },
+						{
+							id: '0644cd79-4d8b-4d20-a1ed-13f8b7ed4373',
+							lookupType: 'id',
+							name: 'Sport',
+						},
+						{
+							id: 'f40bb225-86ab-4d85-a98d-bb2ea11fb453',
+							lookupType: 'id',
+							name: 'Features',
+						},
 						{
 							id: 'a368f61c-8bfb-4d5d-9a88-f76123cd22c9',
+							lookupType: 'id',
 							name: 'International sport',
 						},
 					],

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -10,7 +10,11 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
-						{ id: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026', name: 'Headlines' },
+						{
+							id: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026',
+							lookupType: 'id',
+							name: 'Headlines',
+						},
 					],
 				},
 			],
@@ -26,6 +30,7 @@ export const usConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '5a59a4e5-074e-4a2a-8bbe-2743e07ae30f',
+							lookupType: 'id',
 							name: 'Across the country',
 						},
 					],
@@ -41,14 +46,22 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
 					collectionIds: [
-						{ id: '436ed09d-614f-4418-8500-d1fa9e20404e', name: 'US politics' },
+						{
+							id: '436ed09d-614f-4418-8500-d1fa9e20404e',
+							lookupType: 'id',
+							name: 'US politics',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
 					collectionIds: [
-						{ id: '7e70e9f4-1c60-42e1-85ee-01c8621a0acc', name: 'In depth' },
+						{
+							id: '7e70e9f4-1c60-42e1-85ee-01c8621a0acc',
+							lookupType: 'id',
+							name: 'In depth',
+						},
 					],
 				},
 			],
@@ -64,6 +77,7 @@ export const usConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '2e2035e0-7da9-4172-b0b4-787f3e2a4549',
+							lookupType: 'id',
 							name: 'Around the world',
 						},
 					],
@@ -79,29 +93,49 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
-						{ id: '98df412d-b0e7-4d9a-98c2-062642823e94', name: 'Opinion' },
-						{ id: 'us-alpha/features/feature-stories', name: 'Spotlight' },
+						{
+							id: '98df412d-b0e7-4d9a-98c2-062642823e94',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
+						{
+							id: 'us-alpha/features/feature-stories',
+							lookupType: 'id',
+							name: 'Spotlight',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/commentisfree/lite.json',
 					collectionIds: [
-						{ id: 'us-alpha/contributors/feature-stories', name: 'Opinion' },
+						{
+							id: 'us-alpha/contributors/feature-stories',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/us-politics/lite.json',
 					collectionIds: [
-						{ id: '21450e4f-a452-4601-a4b3-03ba00b5da1a', name: 'Opinion' },
+						{
+							id: '21450e4f-a452-4601-a4b3-03ba00b5da1a',
+							lookupType: 'id',
+							name: 'Opinion',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
-						{ id: '5fd45b04-c512-4a8c-a9b5-cc07a6097049', name: 'Explore' },
+						{
+							id: '5fd45b04-c512-4a8c-a9b5-cc07a6097049',
+							lookupType: 'id',
+							name: 'Explore',
+						},
 					],
 				},
 			],
@@ -121,22 +155,38 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
 					collectionIds: [
-						{ id: 'b0e0bc29-41b5-4dd7-8a5e-f5d4129971a7', name: 'US business' },
+						{
+							id: 'b0e0bc29-41b5-4dd7-8a5e-f5d4129971a7',
+							lookupType: 'id',
+							name: 'US business',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/business/lite.json',
 					collectionIds: [
-						{ id: '2be3f39d-9032-4197-9479-fb6da23599ff', name: 'Business ' },
-						{ id: '6d3daff4-2a4b-46e9-a972-2fe41195db94', name: 'In depth' },
+						{
+							id: '2be3f39d-9032-4197-9479-fb6da23599ff',
+							lookupType: 'id',
+							name: 'Business ',
+						},
+						{
+							id: '6d3daff4-2a4b-46e9-a972-2fe41195db94',
+							lookupType: 'id',
+							name: 'In depth',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/sustainable-business/lite.json',
 					collectionIds: [
-						{ id: '7f3c-ab04-684f-76a2', name: 'sustainable business' },
+						{
+							id: '7f3c-ab04-684f-76a2',
+							lookupType: 'id',
+							name: 'sustainable business',
+						},
 					],
 				},
 				{
@@ -145,6 +195,7 @@ export const usConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '723f35eb-2ab4-4fff-941d-7718b2da4fee',
+							lookupType: 'id',
 							name: 'Around the world',
 						},
 					],
@@ -169,26 +220,37 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/culture/lite.json',
 					collectionIds: [
-						{ id: 'us/culture/regular-stories', name: 'Arts' },
+						{
+							id: 'us/culture/regular-stories',
+							lookupType: 'id',
+							name: 'Arts',
+						},
 						{
 							id: '747c8b96-288a-449a-9e54-be657895d20d',
+							lookupType: 'id',
 							name: 'Talking points',
 						},
-						{ id: '84c18e8f-0bc4-4797-bd3c-57664bd29a53', name: 'People' },
+						{
+							id: '84c18e8f-0bc4-4797-bd3c-57664bd29a53',
+							lookupType: 'id',
+							name: 'People',
+						},
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/film/lite.json',
 					collectionIds: [
-						{ id: '1ce8-6c50-425f-9d32', name: 'Film' },
-						{ id: 'b073-c5d7-c8a9-1e32', name: 'News' },
+						{ id: '1ce8-6c50-425f-9d32', lookupType: 'id', name: 'Film' },
+						{ id: 'b073-c5d7-c8a9-1e32', lookupType: 'id', name: 'News' },
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/music/lite.json',
-					collectionIds: [{ id: 'ee1e-171a-2d93-c8c4', name: 'Music' }],
+					collectionIds: [
+						{ id: 'ee1e-171a-2d93-c8c4', lookupType: 'id', name: 'Music' },
+					],
 				},
 			],
 			capiSources: [],
@@ -201,8 +263,12 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/fashion/lite.json',
 					collectionIds: [
-						{ id: 'eb83-f340-cc50-b311', name: 'Fashion' },
-						{ id: '10419891-2ba1-4eb5-bf53-8933e27ffd1f', name: 'The shows' },
+						{ id: 'eb83-f340-cc50-b311', lookupType: 'id', name: 'Fashion' },
+						{
+							id: '10419891-2ba1-4eb5-bf53-8933e27ffd1f',
+							lookupType: 'id',
+							name: 'The shows',
+						},
 					],
 				},
 			],
@@ -216,7 +282,11 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/environment/lite.json',
 					collectionIds: [
-						{ id: '2b027145-7523-4032-a954-5b3121216996', name: 'Environment' },
+						{
+							id: '2b027145-7523-4032-a954-5b3121216996',
+							lookupType: 'id',
+							name: 'Environment',
+						},
 					],
 				},
 			],
@@ -230,9 +300,17 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/science/lite.json',
 					collectionIds: [
-						{ id: 'e9c7-cf23-23b1-363b', name: 'Science' },
-						{ id: 'e7623e60-63fe-4f52-8295-3692ef272beb', name: 'News' },
-						{ id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1', name: 'Key issues' },
+						{ id: 'e9c7-cf23-23b1-363b', lookupType: 'id', name: 'Science' },
+						{
+							id: 'e7623e60-63fe-4f52-8295-3692ef272beb',
+							lookupType: 'id',
+							name: 'News',
+						},
+						{
+							id: '1ccdafee-622a-4dfb-aaca-e3bb995bd5f1',
+							lookupType: 'id',
+							name: 'Key issues',
+						},
 					],
 				},
 			],
@@ -249,8 +327,12 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/technology/lite.json',
 					collectionIds: [
-						{ id: '6bb3-9f76-43bd-4213', name: 'Technology' },
-						{ id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d', name: 'In depth' },
+						{ id: '6bb3-9f76-43bd-4213', lookupType: 'id', name: 'Technology' },
+						{
+							id: 'c4f66912-47c4-4d5b-a52e-a1180bf68e5d',
+							lookupType: 'id',
+							name: 'In depth',
+						},
 					],
 				},
 			],
@@ -264,7 +346,11 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
 					collectionIds: [
-						{ id: 'c8132ecb-e937-4032-b69d-908f09c838a0', name: 'US sports' },
+						{
+							id: 'c8132ecb-e937-4032-b69d-908f09c838a0',
+							lookupType: 'id',
+							name: 'US sports',
+						},
 					],
 				},
 				{
@@ -273,15 +359,18 @@ export const usConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '7f429d4d-0fd8-4bcb-a44c-e90a816847e3',
+							lookupType: 'id',
 							name: 'Across the country',
 						},
-						{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' },
+						{ id: 'f6dd-d7b1-0e85-4650', lookupType: 'id', name: 'Sports' },
 					],
 				},
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
-					collectionIds: [{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' }],
+					collectionIds: [
+						{ id: 'f6dd-d7b1-0e85-4650', lookupType: 'id', name: 'Sports' },
+					],
 				},
 				{
 					sectionContentURL:
@@ -289,6 +378,7 @@ export const usConfig: PressReaderEditionConfig = {
 					collectionIds: [
 						{
 							id: '0e5f4538-b4cf-4c7b-be44-92966eb638dd',
+							lookupType: 'id',
 							name: 'Around the world',
 						},
 					],
@@ -308,7 +398,9 @@ export const usConfig: PressReaderEditionConfig = {
 				{
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/football/lite.json',
-					collectionIds: [{ id: '1a78-862a-834b-b1d3', name: 'Football' }],
+					collectionIds: [
+						{ id: '1a78-862a-834b-b1d3', lookupType: 'id', name: 'Football' },
+					],
 				},
 			],
 			capiSources: ['search?tag=football%2Fmls&order-by=newest'],

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -15,6 +15,15 @@ export const usConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Headlines',
 						},
+						{
+							lookupType: 'index',
+							/**
+							 * Aiming to target the first actual collection on the page, below the hidden
+							 * 'palette styles' collection. This will often be the same as 'Headlines', but
+							 * headlines might be pushed down if there's a special event.
+							 * */
+							index: 1,
+						},
 					],
 				},
 			],

--- a/packages/pressreader/src/processFrontData.test.ts
+++ b/packages/pressreader/src/processFrontData.test.ts
@@ -1,5 +1,6 @@
 import { processFrontData } from './processEdition';
 import type { PressedFrontPage } from './types/PressedFrontTypes';
+import type { CollectionIdentifiers } from './types/PressReaderTypes';
 
 const dummyContentTemplate = {
 	id: 'string',
@@ -30,6 +31,7 @@ const collection1 = {
 	displayName: 'name',
 	content: [content1, content2],
 };
+
 const collection2 = {
 	id: 'def',
 	displayName: 'my container',
@@ -47,18 +49,21 @@ function collectionMismatchAlarm() {
 
 describe('processFrontData', () => {
 	it('should get stories from each of the matching collections', () => {
+		const collectionIds: CollectionIdentifiers[] = [
+			{
+				id: 'abc',
+				lookupType: 'id',
+				name: 'name',
+			},
+			{
+				id: 'def',
+				lookupType: 'id',
+				name: 'my container',
+			},
+		];
 		const frontConfigWithData = {
 			sectionContentURL: 'sectionContentURL',
-			collectionIds: [
-				{
-					id: 'abc',
-					name: 'name',
-				},
-				{
-					id: 'def',
-					name: 'my container',
-				},
-			],
+			collectionIds,
 			data: pressedPage,
 		};
 		expect(
@@ -67,31 +72,52 @@ describe('processFrontData', () => {
 	});
 
 	it('should match a collection by id even if capitalisation differs', () => {
+		const collectionIds: CollectionIdentifiers[] = [
+			{
+				id: 'DEF',
+				lookupType: 'id',
+				name: 'my container',
+			},
+		];
 		const frontConfigWithData = {
 			sectionContentURL: 'sectionContentURL',
 			data: pressedPage,
-			collectionIds: [
-				{
-					id: 'DEF',
-					name: 'my container',
-				},
-			],
+			collectionIds,
 		};
 		expect(
 			processFrontData(frontConfigWithData, collectionMismatchAlarm),
 		).toEqual(['3']);
 	});
 
-	it('should ignore unmatched collections', () => {
+	it('should match a collection by index', () => {
+		const collectionIds: CollectionIdentifiers[] = [
+			{
+				index: 0,
+				lookupType: 'index',
+			},
+		];
 		const frontConfigWithData = {
 			sectionContentURL: 'sectionContentURL',
 			data: pressedPage,
-			collectionIds: [
-				{
-					id: 'non-existent-colection-id',
-					name: 'n/a',
-				},
-			],
+			collectionIds,
+		};
+		expect(
+			processFrontData(frontConfigWithData, collectionMismatchAlarm),
+		).toEqual(['1', '2']);
+	});
+
+	it('should ignore unmatched collections', () => {
+		const collectionIds: CollectionIdentifiers[] = [
+			{
+				id: 'non-existent-colection-id',
+				lookupType: 'id',
+				name: 'n/a',
+			},
+		];
+		const frontConfigWithData = {
+			sectionContentURL: 'sectionContentURL',
+			data: pressedPage,
+			collectionIds,
 		};
 		expect(
 			processFrontData(frontConfigWithData, collectionMismatchAlarm),
@@ -105,19 +131,23 @@ describe('processFrontData', () => {
 			alarmHasBeenCalled = true;
 		}
 
+		const collectionIds: CollectionIdentifiers[] = [
+			{
+				id: 'def',
+				lookupType: 'id',
+				name: 'My Container',
+			},
+			{
+				id: 'non-existent-colection-id',
+				lookupType: 'id',
+				name: 'n/a',
+			},
+		];
+
 		const frontConfigWithData = {
 			sectionContentURL: 'sectionContentURL',
 			data: pressedPage,
-			collectionIds: [
-				{
-					id: 'def',
-					name: 'My Container',
-				},
-				{
-					id: 'non-existent-colection-id',
-					name: 'n/a',
-				},
-			],
+			collectionIds,
 		};
 		processFrontData(frontConfigWithData, alarmFunction);
 		expect(alarmHasBeenCalled).toEqual(true);

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -23,7 +23,8 @@ export interface SectionConfig {
 	capiSources: string[];
 }
 
-export interface CollectionIdentifiers {
+interface IdLookupConfig {
+	lookupType: 'id';
 	/**
 	 * The unique id of a collection as it occurs in the pressed front json.
 	 * Usually this is a 'UUID'-style string (e.g.
@@ -45,6 +46,21 @@ export interface CollectionIdentifiers {
 	 */
 	name: string;
 }
+
+interface IndexLookupConfig {
+	lookupType: 'index';
+	/**
+	 * The index of the collection in the pressed front json.
+	 * Nb. this is zero-indexed, and the collections may not be in the same order
+	 * in the pressed front json as they are on the corresponding webpage for the same front.
+	 * For example, currently there is a hidden collection on the UK front page called
+	 * 'palette styles new do not delete' which is the first collection on each page.
+	 * While that collection is there, it's unlikely that the value of `index` should be `0`.
+	 */
+	index: number;
+}
+
+export type CollectionIdentifiers = IdLookupConfig | IndexLookupConfig;
 
 export interface FrontSource {
 	/**

--- a/packages/pressreader/src/types/PressedFrontTypes.ts
+++ b/packages/pressreader/src/types/PressedFrontTypes.ts
@@ -8,7 +8,7 @@ export interface PressedFrontPage {
 	collections: CollectionType[];
 }
 
-interface CollectionType {
+export interface CollectionType {
 	id: string;
 	displayName: string;
 	content: ContentType[];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Index-based lookups were previously removed in #39 in favour of looking up collections by their id. However, we've since found out that there are some valid cases for looking up a collection by index instead of id. In particular, the editors want to be able to pull stories from the first collection on some pages, as new temporary collections are sometimes used to display important stories at the top of the page.

Because the lookup logic was refactored in #39 in order to add id-based lookup, this PR doesn't just revert the previous change.

## How to test

I've added a unit test for index-based lookups. One could also run the lambda either locally or in CODE and check the output.

## Have we considered potential risks

There's some potential for index-based lookups to target collections that we wouldn't have wanted to include, but this form of lookup has been used for some time without any obvious issues from an editorial perspective. The index lookup has been broken for some time because it was targeting the 0th collection, which was actually a hidden container with no articles in it. But the containers being added in this PR are actively curated so it should be relatively low risk.