### PR TITLE
Add tone filters to Section config

### DIFF
--- a/packages/pressreader/src/checkArticlesForSection.test.ts
+++ b/packages/pressreader/src/checkArticlesForSection.test.ts
@@ -1,0 +1,95 @@
+import { checkArticlesForSection } from './processEdition';
+import type { CapiItem, Tag } from './types/CapiTypes';
+
+const dummyTag: Tag = {
+	id: 'tag-name',
+	type: 'tone',
+};
+
+const defaultArticle: CapiItem = {
+	id: '123',
+	type: 'article',
+	webPublicationDate: new Date().toDateString(),
+	wordcount: 1100,
+	tags: [],
+};
+
+describe('checkArticlesForSection', () => {
+	it('should filter out undefined values from the articles list', () => {
+		const articles: Array<CapiItem | undefined> = [
+			undefined,
+			defaultArticle,
+			undefined,
+		];
+		const result = checkArticlesForSection(undefined, articles);
+		expect(result).toEqual([defaultArticle]);
+	});
+
+	it('should remove articles that have a tone tag matching an `excludeAll` filter', () => {
+		const articleToInclude: CapiItem = {
+			...defaultArticle,
+			tags: [dummyTag],
+		};
+		const articleWithExcludedToneTag: CapiItem = {
+			...defaultArticle,
+			tags: [{ ...dummyTag, id: 'excludedToneTag' }],
+		};
+		const articleWithDifferentExcludedToneTag: CapiItem = {
+			...defaultArticle,
+			tags: [{ ...dummyTag, id: 'differentExcludedToneTag' }],
+		};
+		const articles = [
+			articleToInclude,
+			articleWithExcludedToneTag,
+			articleWithDifferentExcludedToneTag,
+		];
+		const toneFilters = {
+			filterType: 'excludeAll' as const,
+			list: ['excludedToneTag', 'differentExcludedToneTag'],
+		};
+		const result = checkArticlesForSection(toneFilters, articles);
+		expect(result).toEqual([articleToInclude]);
+	});
+
+	it('should only return articles that have a tone tag matching an `includeOnly` filter', () => {
+		const articleWithNoTags: CapiItem = {
+			...defaultArticle,
+			tags: [],
+		};
+		const articleWithIncludedToneTag: CapiItem = {
+			...defaultArticle,
+			tags: [{ ...dummyTag, id: 'includedToneTag' }],
+		};
+		const articleWithDifferentIncludedToneTag: CapiItem = {
+			...defaultArticle,
+			tags: [{ ...dummyTag, id: 'differentIncludedToneTag' }],
+		};
+		const articles = [
+			articleWithNoTags,
+			articleWithIncludedToneTag,
+			articleWithDifferentIncludedToneTag,
+		];
+		const toneFilters = {
+			filterType: 'includeOnly' as const,
+			list: ['includedToneTag', 'differentIncludedToneTag'],
+		};
+		const result = checkArticlesForSection(toneFilters, articles);
+		expect(result).toEqual([
+			articleWithIncludedToneTag,
+			articleWithDifferentIncludedToneTag,
+		]);
+	});
+
+	it('should return all articles if no tone filters are provided', () => {
+		const articleWithSomeTags: CapiItem = {
+			...defaultArticle,
+			tags: [
+				{ type: 'tone', id: 'someToneTag' },
+				{ type: 'keyword', id: 'someKeywordTag' },
+			],
+		};
+		const articles = [articleWithSomeTags, defaultArticle];
+		const result = checkArticlesForSection(undefined, articles);
+		expect(result).toEqual(articles);
+	});
+});

--- a/packages/pressreader/src/meetsInclusionCriteria.test.ts
+++ b/packages/pressreader/src/meetsInclusionCriteria.test.ts
@@ -1,7 +1,5 @@
-import type { Tag } from '@guardian/content-api-models/v1/tag';
-import { TagType } from '@guardian/content-api-models/v1/tagType';
 import { meetsInclusionCriteria } from './processEdition';
-import type { CapiItem } from './types/CapiTypes';
+import type { CapiItem, Tag } from './types/CapiTypes';
 
 const mockNow = '2023-05-22T05:00:47Z';
 const lessThan24HoursAgo = '2023-05-21T05:00:49Z';
@@ -10,11 +8,7 @@ const minWordCount = 1000;
 
 const dummyTag: Tag = {
 	id: '',
-	type: TagType.KEYWORD,
-	webTitle: '',
-	webUrl: '',
-	apiUrl: '',
-	references: [],
+	type: 'keyword',
 };
 
 const passingArticle: CapiItem = {

--- a/packages/pressreader/src/typePredicates.ts
+++ b/packages/pressreader/src/typePredicates.ts
@@ -1,5 +1,5 @@
 import type { ItemResponse } from '@guardian/content-api-models/v1/itemResponse';
-import type { CapiSearchResponse } from './types/CapiTypes';
+import type { CapiItemResponse, CapiSearchResponse } from './types/CapiTypes';
 import type { PressedFrontPage } from './types/PressedFrontTypes';
 
 export function isCapiSearchResponse(
@@ -31,7 +31,7 @@ export function isNotUndefined<T>(value: T | undefined): value is T {
 	return value !== undefined;
 }
 
-export function isCapiItemResponse(data: unknown): data is ItemResponse {
+export function isCapiItemResponse(data: unknown): data is CapiItemResponse {
 	return (
 		data != null &&
 		(typeof data === 'object' || typeof data === 'function') &&

--- a/packages/pressreader/src/types/CapiTypes.ts
+++ b/packages/pressreader/src/types/CapiTypes.ts
@@ -1,8 +1,19 @@
-import type { Tag } from '@guardian/content-api-models/v1/tag';
-
 export interface CapiSearchResponse {
 	response: {
 		results: Array<{ id: string; type: 'article' }>;
+	};
+}
+
+export interface CapiItemResponse {
+	status: 'ok';
+	content?: {
+		id: string;
+		type: string;
+		webPublicationDate?: string;
+		fields?: {
+			wordcount?: string;
+		};
+		tags: Tag[];
 	};
 }
 
@@ -12,4 +23,9 @@ export interface CapiItem {
 	webPublicationDate: string;
 	tags: Tag[];
 	wordcount: number;
+}
+
+export interface Tag {
+	id: string;
+	type: string;
 }

--- a/packages/pressreader/src/types/PressReaderTypes.ts
+++ b/packages/pressreader/src/types/PressReaderTypes.ts
@@ -21,7 +21,30 @@ export interface SectionConfig {
 	 * @example `["search?tag=science%2Fscience&production-office=us&order-by=newest"]`
 	 */
 	capiSources: string[];
+	/**
+	 * Tone filters will be used to filter articles from a section, (prior to the
+	 * `bannedTags` filter, which is applied to articles for a whole edition.
+	 * For example, features might be included in a section called 'long reads', but
+	 * we wouldn't want to include non-feature long-reads. An `includeOnly` filter
+	 * could be used to ensure that only articles with the 'features' tone tag are
+	 * included in the section.
+	 * Leave as `undefined` if you don't want to filter articles by tone in the section.
+	 */
+	toneFilters?: ToneFilters;
 }
+
+export type ToneFilters = {
+	/**
+	 * If `filterType` is `includeOnly`, then only articles that have a tone tag that
+	 * matches one or more of the tags in `list` will be included. If `filterType` is
+	 * `excludeAll`, then articles that have one or more tone tags that matches one of the tags
+	 * in `list` will be excluded.
+	 * If you don't want to filter articles by tone, then leave `toneFilters` as `undefined`
+	 * in the `SectionConfig`
+	 */
+	filterType: 'includeOnly' | 'excludeAll';
+	list: string[];
+};
 
 interface IdLookupConfig {
 	lookupType: 'id';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Restructure the way Sections are processed, to allow us to filter articles by tone tags within a given section. (The existing 'bannedTags' list applies to the whole edition, rather than specific sections.)
- Add unit tests for the `checkArticlesForSection` function.
- Refactor the `Tag` type and `CapiItemResponse` type because the one we were importing from the CAPI types library didn't represent the tag 'type' (e.g. 'keyword', 'tone') accurately.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Unit tests via `npm run test`.
- [x] Deploy to CODE and run one of the lambdas alongside the corresponding INFRA lambda. The output should be the same because we haven't added any filters yet.
- [x] Add inclusion and exclusion filters to the config for one of the editions and run either locally or on CODE to check that the filters are respected in the output.


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We can implement the new config that has been passed to us by Editorial, which includes tone filters.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

