### PR TITLE
Add dependency groups (cdk and non-cdk)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+    groups:
+      cdk-dependencies:
+        patterns:
+          - "@guardian/cdk"
+      non-cdk-dependencies:
+        exclude-patterns:
+          - "@guardian/cdk"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds Dependabot settings to get it to group dependency update PRs, instead of raising one for each dependency. This adds two groups: `cdk-dependencies` and `non-cdk-dependencies`. [Documentation for the 'groups' setting](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

I've linted the YAML changes. Beyond that, we may need to wait until Dependabot raises a new dependency PR to see whether it works as intended. If we're keen to do so we could temporarily make it raise them more often. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Spend less time reviewing and merging dependency PRs, more easily keep deps up to date. Doesn't rely on custom workflows or third party GHA actions.

## Have we considered potential risks?

Worth noting that this feature is officially [in beta](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/), so we should keep an eye out for any issues. However, the relatively small number of dependencies in this project made it feel like a good candidate for trying out this beta feature. If it takes a little while for the PRs to become stable then it shouldn't take too long for us to catch up with our dependency bumps.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
