### PR TITLE
Fix: Add 'patterns' to non-cdk group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
         patterns:
           - "@guardian/cdk"
       non-cdk-dependencies:
+        patterns:
+          - "*"
         exclude-patterns:
           - "@guardian/cdk"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
`patterns` is [a required field for groups](https://github.com/guardian/pressreader/runs/14940084699). Looks like my linting config hasn't caught up with the new schema yet.