### PR TITLE
Config updates: US & AUS

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -41,7 +41,9 @@ export const ausConfig: PressReaderEditionConfig = {
 					],
 				},
 			],
-			capiSources: [],
+			capiSources: [
+				'search?tag=australia-news/indigenous-australians&order-by=newest',
+			],
 		},
 		{
 			displayName: 'Politics',
@@ -239,7 +241,11 @@ export const ausConfig: PressReaderEditionConfig = {
 					],
 				},
 			],
-			capiSources: [],
+			capiSources: [
+				'search?tag=football/a-league&order-by=newest',
+				'search?tag=sport/afl&order-by=newest',
+				'search?tag=sport/nrl&order-by=newest',
+			],
 		},
 	],
 	bannedTags: [

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -150,7 +150,7 @@ export const usConfig: PressReaderEditionConfig = {
 					],
 				},
 			],
-			capiSources: [],
+			capiSources: ['search?tag=business/us-small-business&order-by=newest'],
 		},
 		{
 			displayName: 'The Guardian View',
@@ -277,11 +277,6 @@ export const usConfig: PressReaderEditionConfig = {
 						},
 						{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' },
 					],
-				},
-				{
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
-					collectionIds: [{ id: 'f6dd-d7b1-0e85-4650', name: 'Sports' }],
 				},
 				{
 					sectionContentURL:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
