### PR TITLE
Dependabot should look at root package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/cdk"
+    directory: "/"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
Dependabot was configured to look in the `/cdk` directory for `npm` dependencies, but this directory hasn't existed for a while.

This branch changes the config so that Dependabot will look in the root of the repo for its `package.json`. I _believe_ that it will be able to discover the dependencies in the workspaces for the separate `cdk` and `pressreader` packages from there.