### PR TITLE
Add link to Pressreader grafana dashboard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,4 +30,6 @@ Lambda logs can be viewed using the [`app: pressreader` filter in Kibana on logs
 
 Monitoring on lambda errors is configured in [`./cdk/lib/pressreader.ts`](../packages/cdk/lib/pressreader.ts#L141), and will send alarm events to `newsroom.resilience+alerts@guardian.co.uk`.
 
+Lambda errors, invocations and duration [can be visualised in Grafana](https://metrics.gutools.co.uk/d/Z-KfjN34z/pressreader?orgId=1&from=now-30d&to=now).
+
 The edition configuration specifies a set of collections on Guardian web fronts that the script extracts stories from. Sometimes these collections are removed or renamed. When the script fails to find an expected collection is will send alarm notifications to `newsroom.resilience+notifications@guardian.co.uk`. These notifications don't include details about the missing collections, but more information can be found by searching the [project logs](https://logs.gutools.co.uk/s/newsroom-resilience/goto/8f38a860-fb94-11ed-a6e5-05ce52e0b77b).


### PR DESCRIPTION
## What does this change?

This change adds a link to a Grafana dashboard so invocations, errors and duration can be visualised more easily.

## How to test

- [ ] [View the dashboard](https://metrics.gutools.co.uk/d/Z-KfjN34z/pressreader?orgId=1&from=now-30d&to=now), is it helpful?

<img width="1442" alt="Screenshot 2023-07-25 at 10 21 58" src="https://github.com/guardian/pressreader/assets/953792/b26a97f5-0cea-4a8e-8a62-8502929db99f">

## How can we measure success?

People working with this service can more easily visualise service health and use over time.