### PR TITLE
Temporarily remove broken front link

### DIFF
--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -189,17 +189,6 @@ export const usConfig: PressReaderEditionConfig = {
 				},
 				{
 					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us/sustainable-business/lite.json',
-					collectionIds: [
-						{
-							id: '7f3c-ab04-684f-76a2',
-							lookupType: 'id',
-							name: 'sustainable business',
-						},
-					],
-				},
-				{
-					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/business/lite.json',
 					collectionIds: [
 						{


### PR DESCRIPTION
## What does this change?

Removes the config that targets the `us/sustainable-business` front. Requests to this URL are currently returning a 500 response: `https://api.nextgen.guardianapps.co.uk/us/sustainable-business/lite.json`. In addition, it looks like the front is no longer maintained, as the most recent stories in it are from 2017. Given this, it seems fair to just remove it (though we should probably keep an eye on whether there is a more general issue with the Fronts endpoint that we're using here?)
