### PR TITLE
Add 'first-thing' tag to bannedTags

### DIFF
--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -734,5 +734,6 @@ export const usConfig: PressReaderEditionConfig = {
 	bannedTags: [
 		'sport/series/talking-horses',
 		'science/series/alex-bellos-monday-puzzle',
+		'us-news/series/guardian-us-briefing',
 	],
 };


### PR DESCRIPTION
Add the `us-news/series/guardian-us-briefing` tag to the `bannedTags` list. The articles with this tag belong to the 'first thing' series, which is a newsletter so shouldn't be included in Pressreader editions.

The `bannedTags` functionality was already implemented so hopefully this will be a straightforward change.