### PR TITLE
Only request stories published in last 24 hours

### DIFF
--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -110,8 +110,11 @@ export function editionProcessor({
 }
 
 function CapiSearchUrlFromQuery(query: string, capiConfig: CapiConfig): string {
+	const yesterdayYyyyMmDd = new Date(Date.now() - 24 * 60 * 60 * 1000)
+		.toISOString()
+		.slice(0, 10);
 	return new URL(
-		`${query}&api-key=${capiConfig.capiKey}`,
+		`${query}&from-date=${yesterdayYyyyMmDd}&api-key=${capiConfig.capiKey}`,
 		capiConfig.baseCapiUrl,
 	).toString();
 }


### PR DESCRIPTION
We filter out stories that were published over 24 hours ago. Previously we were doing this after requesting the details for the individual story. However, CAPI allows us to filter our searches by date published, so we can save some unnecessary queries by getting it to do the filtering at the search stage.