### PR TITLE
Offset lambda schedules

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,10 +1,21 @@
 import 'source-map-support/register';
 import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root';
-import { Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { PressReader } from '../lib/pressreader';
 
 const app = new GuRootExperimental();
+
+/**
+ * Each of the INFRA lambdas is scheduled to run every 15 minutes, but the schedules
+ * are offset by 2 minutes to avoid all lambdas running at the same time, to reduce
+ * the likelihood of hitting the CAPI rate limit.
+ */
+const infraSchedules = [
+	Schedule.cron({ minute: '0,15,30,45' }),
+	Schedule.cron({ minute: '2,17,32,47' }),
+	Schedule.cron({ minute: '4,19,34,49' }),
+	Schedule.cron({ minute: '6,21,36,51' }),
+] as const;
 
 new PressReader(app, 'PressReader-INFRA', {
 	env: { region: 'eu-west-1' },
@@ -15,25 +26,40 @@ new PressReader(app, 'PressReader-INFRA', {
 		{
 			editionKey: 'AUS',
 			s3PrefixPath: ['data', 'AUS'],
+			schedule: infraSchedules[0],
 		},
 		{
 			editionKey: 'US',
 			s3PrefixPath: ['data', 'US'],
+			schedule: infraSchedules[1],
 		},
 		{
 			editionKey: 'AUS',
 			s3PrefixPath: [],
 			bucketName: 'press-reader-aus-configs',
+			schedule: infraSchedules[2],
 		},
 		{
 			editionKey: 'US',
 			s3PrefixPath: [],
 			bucketName: 'press-reader-us-configs',
+			schedule: infraSchedules[3],
 		},
 	],
-	schedule: Schedule.rate(Duration.minutes(15)),
 	domainName: 'pressreader.gutools.co.uk',
 });
+
+/**
+ * Each of the INFRA lambdas is scheduled to run once a day, but the schedules
+ * are offset by 2 minutes to avoid all lambdas running at the same time, to reduce
+ * the likelihood of hitting the CAPI rate limit.
+ */
+const codeSchedules = [
+	Schedule.cron({ minute: '0', hour: '10' }),
+	Schedule.cron({ minute: '2', hour: '10' }),
+	Schedule.cron({ minute: '4', hour: '10' }),
+	Schedule.cron({ minute: '6', hour: '10' }),
+] as const;
 
 new PressReader(app, 'PressReader-CODE', {
 	env: { region: 'eu-west-1' },
@@ -44,22 +70,25 @@ new PressReader(app, 'PressReader-CODE', {
 		{
 			editionKey: 'AUS',
 			s3PrefixPath: ['data', 'AUS'],
+			schedule: codeSchedules[0],
 		},
 		{
 			editionKey: 'US',
 			s3PrefixPath: ['data', 'US'],
+			schedule: codeSchedules[1],
 		},
 		{
 			editionKey: 'AUS',
 			s3PrefixPath: ['old-data', 'AUS'],
 			bucketName: 'gu-pressreader-data-code',
+			schedule: codeSchedules[2],
 		},
 		{
 			editionKey: 'US',
 			s3PrefixPath: ['old-data', 'US'],
 			bucketName: 'gu-pressreader-data-code',
+			schedule: codeSchedules[3],
 		},
 	],
-	schedule: Schedule.rate(Duration.days(1)),
 	domainName: 'pressreader.code.dev-gutools.co.uk',
 });

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -1576,7 +1576,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pressreaderTESTAUSoldpressreaderTESTAUSoldrate15minutes0AllowEventRulePressReaderpressreaderTESTAUSold46DB6A52628B8658": {
+    "pressreaderTESTAUSoldpressreaderTESTAUSoldcron150AllowEventRulePressReaderpressreaderTESTAUSold46DB6A520E73403A": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1588,16 +1588,16 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderTESTAUSoldpressreaderTESTAUSoldrate15minutes0E1CE297C",
+            "pressreaderTESTAUSoldpressreaderTESTAUSoldcron150EA5C7897",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "pressreaderTESTAUSoldpressreaderTESTAUSoldrate15minutes0E1CE297C": {
+    "pressreaderTESTAUSoldpressreaderTESTAUSoldcron150EA5C7897": {
       "Properties": {
-        "ScheduleExpression": "rate(15 minutes)",
+        "ScheduleExpression": "cron(15 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -1613,9 +1613,9 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderTESTAUSpressreaderTESTAUSrate15minutes046435523": {
+    "pressreaderTESTAUSpressreaderTESTAUScron1500E085ACC": {
       "Properties": {
-        "ScheduleExpression": "rate(15 minutes)",
+        "ScheduleExpression": "cron(15 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -1631,7 +1631,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderTESTAUSpressreaderTESTAUSrate15minutes0AllowEventRulePressReaderpressreaderTESTAUS382F54FF4D3C6686": {
+    "pressreaderTESTAUSpressreaderTESTAUScron150AllowEventRulePressReaderpressreaderTESTAUS382F54FF180AD9D2": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1643,7 +1643,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderTESTAUSpressreaderTESTAUSrate15minutes046435523",
+            "pressreaderTESTAUSpressreaderTESTAUScron1500E085ACC",
             "Arn",
           ],
         },
@@ -2466,9 +2466,9 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "pressreaderTESTUSoldpressreaderTESTUSoldrate15minutes002919872": {
+    "pressreaderTESTUSoldpressreaderTESTUSoldcron15037AB71BC": {
       "Properties": {
-        "ScheduleExpression": "rate(15 minutes)",
+        "ScheduleExpression": "cron(15 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -2484,7 +2484,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderTESTUSoldpressreaderTESTUSoldrate15minutes0AllowEventRulePressReaderpressreaderTESTUSoldBFB7FA9608E25E64": {
+    "pressreaderTESTUSoldpressreaderTESTUSoldcron150AllowEventRulePressReaderpressreaderTESTUSoldBFB7FA96A6A6A567": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -2496,16 +2496,16 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderTESTUSoldpressreaderTESTUSoldrate15minutes002919872",
+            "pressreaderTESTUSoldpressreaderTESTUSoldcron15037AB71BC",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "pressreaderTESTUSpressreaderTESTUSrate15minutes0191622F6": {
+    "pressreaderTESTUSpressreaderTESTUScron1508ABFF8CD": {
       "Properties": {
-        "ScheduleExpression": "rate(15 minutes)",
+        "ScheduleExpression": "cron(15 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -2521,7 +2521,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "pressreaderTESTUSpressreaderTESTUSrate15minutes0AllowEventRulePressReaderpressreaderTESTUS2CC9488566095411": {
+    "pressreaderTESTUSpressreaderTESTUScron150AllowEventRulePressReaderpressreaderTESTUS2CC9488571D740B8": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -2533,7 +2533,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "pressreaderTESTUSpressreaderTESTUSrate15minutes0191622F6",
+            "pressreaderTESTUSpressreaderTESTUScron1508ABFF8CD",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/pressreader.test.ts
+++ b/packages/cdk/lib/pressreader.test.ts
@@ -1,7 +1,9 @@
-import { App, Duration } from 'aws-cdk-lib';
+import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { PressReader } from './pressreader';
+
+const schedule = Schedule.cron({ minute: '15' });
 
 describe('The PressReader stack', () => {
 	it('matches the snapshot', () => {
@@ -10,20 +12,21 @@ describe('The PressReader stack', () => {
 			stack: 'print-production',
 			stage: 'TEST',
 			lambdaConfigs: [
-				{ editionKey: 'AUS', s3PrefixPath: ['data', 'AUS'] },
-				{ editionKey: 'US', s3PrefixPath: ['data', 'US'] },
+				{ editionKey: 'AUS', s3PrefixPath: ['data', 'AUS'], schedule },
+				{ editionKey: 'US', s3PrefixPath: ['data', 'US'], schedule },
 				{
 					editionKey: 'AUS',
 					s3PrefixPath: [],
 					bucketName: 'press-reader-aus-configs',
+					schedule,
 				},
 				{
 					editionKey: 'US',
 					s3PrefixPath: [],
 					bucketName: 'press-reader-us-configs',
+					schedule,
 				},
 			],
-			schedule: Schedule.rate(Duration.minutes(15)),
 			domainName: 'pressreader.test.dev-gutools.co.uk',
 		});
 		const template = Template.fromStack(stack);

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -28,8 +28,8 @@ export interface PressReaderProps extends GuStackProps {
 		bucketName?: string;
 		editionKey: EditionKey;
 		s3PrefixPath: string[];
+		schedule: Schedule;
 	}>;
-	schedule: Schedule;
 	domainName: string;
 }
 
@@ -253,7 +253,7 @@ export class PressReader extends GuStack {
 						lengthOfEvaluationPeriod: Duration.minutes(15),
 						numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 3,
 					},
-					rules: [{ schedule: props.schedule }],
+					rules: [{ schedule: config.schedule }],
 					timeout: Duration.seconds(300),
 				},
 			);


### PR DESCRIPTION
## What does this change?

Use a cron expression to schedule the lambdas, so that we can run them at a slight offset from each other. The intention is that it should reduce the chance of hitting the rate limit on the shared CAPI key.

## How to test

Deploy and check that it runs on the intended schedule.

## How can we measure success?

Fewer rate limit issues.
