### PR TITLE
Set curly apostrophe to resolve name mismatch

### DIFF
--- a/packages/cdk/jest.setup.js
+++ b/packages/cdk/jest.setup.js
@@ -1,1 +1,1 @@
-jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock('@guardian/cdk/lib/constants/tracking-tag');

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -554,7 +554,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						{
 							id: 'a32d32a5-ad1e-4e74-bfef-fa98e0360299',
 							lookupType: 'id',
-							name: "Women's World Cup 2023",
+							name: 'Women’s World Cup 2023',
 						},
 					],
 				},


### PR DESCRIPTION
As the title says