### PR TITLE
Separate CAPI secrets and run the new lambdas less often

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -9,10 +9,14 @@ const app = new GuRootExperimental();
  * Each of the INFRA lambdas is scheduled to run every 15 minutes, but the schedules
  * are offset by 2 minutes to avoid all lambdas running at the same time, to reduce
  * the likelihood of hitting the CAPI rate limit.
+ * The monitoring for each lambda assumes that they're running every 15 minutes, so
+ * the 'new' lambdas (which are not yet used in production) are schedules to run
+ * every 4 times in one hour per day. This way we should be alerted to any issues,
+ * without running them too often.
  */
 const infraSchedules = [
-	Schedule.cron({ minute: '0,15,30,45' }),
-	Schedule.cron({ minute: '2,17,32,47' }),
+	Schedule.cron({ minute: '0,15,30,45', hour: '10' }),
+	Schedule.cron({ minute: '2,17,32,47', hour: '10' }),
 	Schedule.cron({ minute: '4,19,34,49' }),
 	Schedule.cron({ minute: '6,21,36,51' }),
 ] as const;
@@ -34,12 +38,22 @@ new PressReader(app, 'PressReader-INFRA', {
 			schedule: infraSchedules[1],
 		},
 		{
+			/**
+			 * This is the 'legacy' AUS config, which writes to the bucket currently
+			 * used in production. It should be removed after Pressreader start using
+			 * the new API key.
+			 * */
 			editionKey: 'AUS',
 			s3PrefixPath: [],
 			bucketName: 'press-reader-aus-configs',
 			schedule: infraSchedules[2],
 		},
 		{
+			/**
+			 * This is the 'legacy' US config, which writes to the bucket currently
+			 * used in production. It should be removed after Pressreader start using
+			 * the new API key.
+			 * */
 			editionKey: 'US',
 			s3PrefixPath: [],
 			bucketName: 'press-reader-us-configs',
@@ -49,11 +63,6 @@ new PressReader(app, 'PressReader-INFRA', {
 	domainName: 'pressreader.gutools.co.uk',
 });
 
-/**
- * Each of the INFRA lambdas is scheduled to run once a day, but the schedules
- * are offset by 2 minutes to avoid all lambdas running at the same time, to reduce
- * the likelihood of hitting the CAPI rate limit.
- */
 const codeSchedules = [
 	Schedule.cron({ minute: '0', hour: '10' }),
 	Schedule.cron({ minute: '2', hour: '10' }),

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -144,12 +144,96 @@ exports[`The PressReader stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CapiTokenSecret1D3F4E33": {
+    "CapiTokenSecretAUSE7DED8BD": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "Description": "The CAPI token used to retrieve content",
         "GenerateSecretString": {},
-        "Name": "/TEST/print-production/pressreader/capiToken",
+        "Name": "/TEST/print-production/pressreader/capiTokenAUS",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CapiTokenSecretAUSold88B029DA": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "The CAPI token used to retrieve content",
+        "GenerateSecretString": {},
+        "Name": "/TEST/print-production/pressreader/capiTokenAUS-old",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CapiTokenSecretUS61320231": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "The CAPI token used to retrieve content",
+        "GenerateSecretString": {},
+        "Name": "/TEST/print-production/pressreader/capiTokenUS",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pressreader",
+          },
+          {
+            "Key": "Stack",
+            "Value": "print-production",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CapiTokenSecretUSoldF93AFBE7": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "The CAPI token used to retrieve content",
+        "GenerateSecretString": {},
+        "Name": "/TEST/print-production/pressreader/capiTokenUS-old",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -795,7 +879,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretAUSE7DED8BD",
                                   },
                                 ],
                               },
@@ -818,7 +902,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretAUSE7DED8BD",
                                   },
                                 ],
                               },
@@ -1132,7 +1216,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               "Action": "secretsmanager:GetSecretValue",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "CapiTokenSecret1D3F4E33",
+                "Ref": "CapiTokenSecretAUSE7DED8BD",
               },
             },
             {
@@ -1203,7 +1287,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretAUSold88B029DA",
                                   },
                                 ],
                               },
@@ -1226,7 +1310,30 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretAUSold88B029DA",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecretAUSold88B029DA",
                                   },
                                 ],
                               },
@@ -1540,7 +1647,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               "Action": "secretsmanager:GetSecretValue",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "CapiTokenSecret1D3F4E33",
+                "Ref": "CapiTokenSecretAUSold88B029DA",
               },
             },
             {
@@ -1685,7 +1792,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretUS61320231",
                                   },
                                 ],
                               },
@@ -1708,7 +1815,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretUS61320231",
                                   },
                                 ],
                               },
@@ -2022,7 +2129,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               "Action": "secretsmanager:GetSecretValue",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "CapiTokenSecret1D3F4E33",
+                "Ref": "CapiTokenSecretUS61320231",
               },
             },
             {
@@ -2093,7 +2200,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretUSoldF93AFBE7",
                                   },
                                 ],
                               },
@@ -2116,7 +2223,30 @@ exports[`The PressReader stack matches the snapshot 1`] = `
                                 "Fn::Split": [
                                   ":",
                                   {
-                                    "Ref": "CapiTokenSecret1D3F4E33",
+                                    "Ref": "CapiTokenSecretUSoldF93AFBE7",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "CapiTokenSecretUSoldF93AFBE7",
                                   },
                                 ],
                               },
@@ -2430,7 +2560,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
               "Action": "secretsmanager:GetSecretValue",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "CapiTokenSecret1D3F4E33",
+                "Ref": "CapiTokenSecretUSoldF93AFBE7",
               },
             },
             {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Two main changes:

1. Each of the four lambdas created by the CDK has its own Secrets Manager location for its CAPI token.
2. The 'new' lambdas (which serve their output via API Gateway) have their schedules adjusted to run less often.
  * nb. The monitoring config assumes that the lambdas are run every 15 minutes, so I've made these run 4 times per hour, but only for one hour during each day.

## Why?

We're hitting the CAPI rate limit, and also using energy and money unnecessarily by running all four lambdas so regularly, while only two are actually being used.

## Deployment

We'll need to manually fill in the new Secrets Manager values after deployment.