### PR TITLE
Update lambda schedules for switch-over

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -15,10 +15,10 @@ const app = new GuRootExperimental();
  * without running them too often.
  */
 const infraSchedules = [
-	Schedule.cron({ minute: '0,15,30,45', hour: '10' }),
-	Schedule.cron({ minute: '2,17,32,47', hour: '10' }),
-	Schedule.cron({ minute: '4,19,34,49' }),
-	Schedule.cron({ minute: '6,21,36,51' }),
+	Schedule.cron({ minute: '0,15,30,45' }),
+	Schedule.cron({ minute: '2,17,32,47' }),
+	Schedule.cron({ minute: '4,19,34,49', hour: '0,4,8,12,16,20' }),
+	Schedule.cron({ minute: '6,21,36,51', hour: '0,4,8,12,16,20' }),
 ] as const;
 
 new PressReader(app, 'PressReader-INFRA', {


### PR DESCRIPTION
> **Warning**
> This should not be merged until we know when Pressreader are going to switch over their access method.

## What's changed?

Increase the frequency of the 'new' lambdas so that they run every hour. Reduce the frequency of the 'old' lambdas to once every 4 hours.

This is in anticipation of Pressreader switching over from using the legacy access point to using the new API.

Once we've confirmed that the switch is working as planned, we can remove the 'old' lambdas entirely.

## How to test

We can't easily test this because the schedules (intentionally) differ between INFRA and CODE stages. That said, the only change should be to scheduling, so if we're confident that the cron definitions are correct then we should be fine, and can check that they're running as expected once deployed.