### PR TITLE
Run all PROD lambdas every hour

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -15,8 +15,8 @@ const app = new GuRootExperimental();
  * without running them too often.
  */
 const infraSchedules = [
-	Schedule.cron({ minute: '0,15,30,45', hour: '10' }),
-	Schedule.cron({ minute: '2,17,32,47', hour: '10' }),
+	Schedule.cron({ minute: '0,15,30,45' }),
+	Schedule.cron({ minute: '2,17,32,47' }),
 	Schedule.cron({ minute: '4,19,34,49' }),
 	Schedule.cron({ minute: '6,21,36,51' }),
 ] as const;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Run the 'new' lambdas every hour, as well as the old ones. Pressreader will be switching over from one to the other soon, but we're not sure when, so we want to make sure that there's data available via both methods temporarily. I'm increasing the rate limit on the CAPI tokens temporarily, until we switch the old lambdas off.
