### PR TITLE
Don't error if CAPI article lookup returns 404

### DIFF
--- a/packages/pressreader/src/fetchArticleData.test.ts
+++ b/packages/pressreader/src/fetchArticleData.test.ts
@@ -1,0 +1,66 @@
+import axios from 'axios';
+import { capiResponseToCapiItem, fetchArticleData } from './processEdition';
+import type { CapiItemResponse } from './types/CapiTypes';
+
+jest.mock('axios');
+
+describe('fetchArticleData', () => {
+	it('should return "undefined" if CAPI returns a 404', async () => {
+		const resp = { data: {}, status: 404 };
+		const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+		mockedAxios.get.mockResolvedValue(resp);
+
+		const data = await fetchArticleData('abc', {
+			baseCapiUrl: 'https://example.com',
+			capiKey: 'key',
+		});
+		return expect(data).toBeUndefined();
+	});
+
+	it('should return the article id if CAPI returns a valid article response', async () => {
+		const articleData: CapiItemResponse = {
+			status: 'ok',
+			content: {
+				id: 'us-news/2023/nov/20/first-thing-richest-1-account-for-more-carbon-emissions-than-poorest-66',
+				type: 'article',
+				webPublicationDate: '2023-11-20T11:50:12Z',
+				fields: { wordcount: '1384' },
+				tags: [
+					{
+						id: 'us-news/series/guardian-us-briefing',
+						type: 'series',
+					},
+					{
+						id: 'type/article',
+						type: 'type',
+					},
+				],
+			},
+		};
+		const resp = { data: { response: articleData }, status: 200 };
+		const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+		mockedAxios.get.mockResolvedValue(resp);
+
+		const data = await fetchArticleData(articleData.content.id, {
+			baseCapiUrl: 'https://example.com',
+			capiKey: 'key',
+		});
+		return expect(data).toStrictEqual(capiResponseToCapiItem(articleData));
+	});
+
+	it('should throw an error if returned data is not a valid CAPI response', async () => {
+		const resp = { data: { response: {} }, status: 200 };
+		const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+		mockedAxios.get.mockResolvedValue(resp);
+
+		await expect(
+			fetchArticleData('abc', {
+				baseCapiUrl: 'https://example.com',
+				capiKey: 'key',
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -356,9 +356,7 @@ export function capiResponseToCapiItem(
 ): CapiItem | undefined {
 	try {
 		const wordcount = parseInt(response.content.fields.wordcount);
-		const type = response.content.type;
-		const webPublicationDate = response.content.webPublicationDate;
-		return { ...response.content, webPublicationDate, wordcount, type };
+		return { ...response.content, wordcount };
 	} catch (e) {
 		throw new Error('CAPI item has invalid wordcount value');
 	}

--- a/packages/pressreader/src/types/CapiTypes.ts
+++ b/packages/pressreader/src/types/CapiTypes.ts
@@ -6,12 +6,12 @@ export interface CapiSearchResponse {
 
 export interface CapiItemResponse {
 	status: 'ok';
-	content?: {
+	content: {
 		id: string;
 		type: string;
-		webPublicationDate?: string;
-		fields?: {
-			wordcount?: string;
+		webPublicationDate: string;
+		fields: {
+			wordcount: string;
 		};
 		tags: Tag[];
 	};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Pass a custom `validateStatus` function to `axios.get`, which treats 404 as a valid status. This prevents axios from erroring on a 404 code.

We sometimes get invalid or outdated CAPI ids from the fronts API, and there's nothing we can do about it, so it's better to just log the issue and keep moving without the article in question.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run the unit tests, which should confirm the desired 404 behaviour.
- [x] Run in CODE and check that the output is the same as in PROD.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Fewer un-actionable error alarms triggered. Less noise 👍

