### PR TITLE
Improve CAPI Item type predicate checks and misc refactors

### DIFF
--- a/packages/pressreader/src/example.test.ts
+++ b/packages/pressreader/src/example.test.ts
@@ -1,5 +1,0 @@
-describe('a test', function () {
-	it('should pass', function () {
-		expect(true).toBe(true);
-	});
-});

--- a/packages/pressreader/src/processFrontData.test.ts
+++ b/packages/pressreader/src/processFrontData.test.ts
@@ -109,7 +109,7 @@ describe('processFrontData', () => {
 	it('should ignore unmatched collections', () => {
 		const collectionIds: CollectionIdentifiers[] = [
 			{
-				id: 'non-existent-colection-id',
+				id: 'non-existent-collection-id',
 				lookupType: 'id',
 				name: 'n/a',
 			},
@@ -138,7 +138,7 @@ describe('processFrontData', () => {
 				name: 'My Container',
 			},
 			{
-				id: 'non-existent-colection-id',
+				id: 'non-existent-collection-id',
 				lookupType: 'id',
 				name: 'n/a',
 			},

--- a/packages/pressreader/src/typePredicates.test.ts
+++ b/packages/pressreader/src/typePredicates.test.ts
@@ -3,13 +3,35 @@ import {
 	isCapiSearchResponse,
 	isPressedFrontPage,
 } from './typePredicates';
+import type { CapiItemResponse } from './types/CapiTypes';
 
 describe('isCapiItemResponse', () => {
-	it('should return true if the data has {status: "okay"}', () => {
-		expect(isCapiItemResponse({ status: 'ok' })).toBe(true);
+	const validCapiItemResponse: CapiItemResponse = {
+		status: 'ok',
+		content: {
+			id: 'us-news/2023/nov/20/first-thing-richest-1-account-for-more-carbon-emissions-than-poorest-66',
+			type: 'article',
+			webPublicationDate: '2023-11-20T11:50:12Z',
+			fields: { wordcount: '1384' },
+			tags: [
+				{
+					id: 'a',
+					type: 'series',
+				},
+				{
+					id: 'b',
+					type: 'type',
+				},
+			],
+		},
+	};
+	it('should return true if the data has all expected fields', () => {
+		expect(isCapiItemResponse(validCapiItemResponse)).toBe(true);
 	});
 	it('should return false if the data does not have {status: "okay"}', () => {
-		expect(isCapiItemResponse({ status: 'error' })).toBe(false);
+		expect(
+			isCapiItemResponse({ ...validCapiItemResponse, status: 'error' }),
+		).toBe(false);
 	});
 	it('should return false if the data is an empty object', () => {
 		expect(isCapiItemResponse({})).toBe(false);
@@ -20,6 +42,55 @@ describe('isCapiItemResponse', () => {
 		expect(isCapiItemResponse(undefined)).toBe(false);
 		expect(isCapiItemResponse(0)).toBe(false);
 		expect(isCapiItemResponse('')).toBe(false);
+	});
+	it('should return false if content.id is not a string', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, id: 0 },
+			}),
+		).toBe(false);
+	});
+	it('should return false if content.type is not a string', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, type: 0 },
+			}),
+		).toBe(false);
+	});
+	it('should return false if content.webPublicationDate is not a string', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: {
+					...validCapiItemResponse.content,
+					webPublicationDate: 0,
+				},
+			}),
+		).toBe(false);
+	});
+	it('should return false if content.fields.wordcount is not a string', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, fields: 0 },
+			}),
+		).toBe(false);
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, fields: { wordcount: 0 } },
+			}),
+		).toBe(false);
+	});
+	it('should return false if content.tags is not an array', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, tags: 0 },
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/pressreader/src/typePredicates.test.ts
+++ b/packages/pressreader/src/typePredicates.test.ts
@@ -92,6 +92,40 @@ describe('isCapiItemResponse', () => {
 			}),
 		).toBe(false);
 	});
+	it('should be fine with an empty array of tags', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: { ...validCapiItemResponse.content, tags: [] },
+			}),
+		).toBe(true);
+	});
+	it('should return false if content.tags is not an array of objects with id and type both being strings', () => {
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: {
+					...validCapiItemResponse.content,
+					tags: [
+						{ id: 'a', type: 'series' },
+						{ id: 0, type: 'type' },
+					],
+				},
+			}),
+		).toBe(false);
+		expect(
+			isCapiItemResponse({
+				status: 'ok',
+				content: {
+					...validCapiItemResponse.content,
+					tags: [
+						{ id: 'a', type: 'series' },
+						{ id: 'b', type: 0 },
+					],
+				},
+			}),
+		).toBe(false);
+	});
 });
 
 describe('isCapiSearchResponse', () => {

--- a/packages/pressreader/src/typePredicates.ts
+++ b/packages/pressreader/src/typePredicates.ts
@@ -42,7 +42,11 @@ export function isCapiItemResponse(data: unknown): data is CapiItemResponse {
 		typeof (data as ItemResponse).content?.webPublicationDate === 'string' &&
 		typeof (data as ItemResponse).content?.fields === 'object' &&
 		typeof (data as ItemResponse).content?.fields?.wordcount === 'string' &&
-		Array.isArray((data as ItemResponse).content?.tags)
+		Array.isArray((data as ItemResponse).content?.tags) &&
+		((data as ItemResponse).content?.tags.every(
+			(tag) => typeof tag.id === 'string' && typeof tag.type === 'string',
+		) ??
+			false)
 	);
 }
 

--- a/packages/pressreader/src/typePredicates.ts
+++ b/packages/pressreader/src/typePredicates.ts
@@ -34,8 +34,15 @@ export function isNotUndefined<T>(value: T | undefined): value is T {
 export function isCapiItemResponse(data: unknown): data is CapiItemResponse {
 	return (
 		data != null &&
-		(typeof data === 'object' || typeof data === 'function') &&
-		(data as ItemResponse).status == 'ok'
+		typeof data === 'object' &&
+		(data as ItemResponse).status == 'ok' &&
+		typeof (data as ItemResponse).content === 'object' &&
+		typeof (data as ItemResponse).content?.id === 'string' &&
+		typeof (data as ItemResponse).content?.type === 'string' &&
+		typeof (data as ItemResponse).content?.webPublicationDate === 'string' &&
+		typeof (data as ItemResponse).content?.fields === 'object' &&
+		typeof (data as ItemResponse).content?.fields?.wordcount === 'string' &&
+		Array.isArray((data as ItemResponse).content?.tags)
 	);
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Check all required fields in the CAPI item response, as part of the `isCapiItemResponse` type predicate.
- Delete an unused example test file.
- Fix a typo in a test case.

This is in preparation for #120, where we want to know that we have all required fields in the CAPI item data before processing it.
