### PR TITLE
Make it possible to disable non-critical notifications per stack

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -15,7 +15,7 @@ const infraSchedules = [
 	Schedule.cron({ minute: '2,17,32,47' }),
 ] as const;
 
-new PressReader(app, 'PressReader-INFRA', {
+export const pressreaderInfraStack = new PressReader(app, 'PressReader-INFRA', {
 	env: { region: 'eu-west-1' },
 	app: 'pressreader',
 	stack: 'print-production',
@@ -33,6 +33,7 @@ new PressReader(app, 'PressReader-INFRA', {
 		},
 	],
 	domainName: 'pressreader.gutools.co.uk',
+	enableNotifications: true,
 });
 
 const codeSchedules = [
@@ -58,4 +59,5 @@ new PressReader(app, 'PressReader-CODE', {
 		},
 	],
 	domainName: 'pressreader.code.dev-gutools.co.uk',
+	enableNotifications: false,
 });

--- a/packages/cdk/lib/pressreader.test.ts
+++ b/packages/cdk/lib/pressreader.test.ts
@@ -1,6 +1,7 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { Schedule } from 'aws-cdk-lib/aws-events';
+import { pressreaderInfraStack } from '../bin/cdk';
 import { PressReader } from './pressreader';
 
 const schedule = Schedule.cron({ minute: '15' });
@@ -16,8 +17,27 @@ describe('The PressReader stack', () => {
 				{ editionKey: 'US', s3PrefixPath: ['data', 'US'], schedule },
 			],
 			domainName: 'pressreader.test.dev-gutools.co.uk',
+			enableNotifications: true,
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
+	});
+});
+
+describe('The actual INFRA stack', () => {
+	it('should have CollectionLookupFailure alarms enabled', () => {
+		/**
+		 * nb. this isn't an exhaustive test of everything that's required for
+		 * the alarms to work, but it should let us know if we accidentally
+		 * disable the alarm, given the config at the time of writing. Testing
+		 * the stack in more detail would likely be be fragile to changes in CDK
+		 * etc., so may not be worth the maintenance overhead.
+		 */
+		const template = Template.fromStack(pressreaderInfraStack);
+		expect(
+			template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+				MetricName: 'CollectionLookupFailure-INFRA',
+			}),
+		);
 	});
 });


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


- Add an `enableNotifications` prop to the Pressreader CDK stack.
- Only create the 'notifications' SNS topic, and the alarm that feeds into it, if `enableNotifications` is `true`.
  - Currently the only feed into the SNS topic is the `CollectionLookupFailureAlarm`, which is based on the `CollectionLookupFailure-${stage}` metric. The metric is still created if notifications are not enabled, and the lambda handler will still publish to this metric.
- Add a test on the template generated for the INFRA stack, to make sure that the alarm _is_ created.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run the tests
- [ ] Deploy to CODE and check that the alarm is not created.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Less noise from the CODE stack for issues that we don't need to bother with. But it's still possible to test the notifications in this stack if we want (this will require a PR, though).