### PR TITLE
Remove world cup 2023 collection, as it's no longer maintained

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -551,11 +551,6 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'International sport',
 						},
-						{
-							id: 'a32d32a5-ad1e-4e74-bfef-fa98e0360299',
-							lookupType: 'id',
-							name: 'Women’s World Cup 2023',
-						},
 					],
 				},
 			],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've been getting `CollectionNotFound` alarms today, and [logs show that it's for the Women's World Cup 2023 collection](https://logs.gutools.co.uk/s/newsroom-resilience/goto/ec311400-112b-11ef-bd02-15bf929da514) on the Australia sports front.

There are no logs showing a name mismatch for this collection, prior to its removal, so it seems surprising that this 2023 event would only just have been removed. However, it does make sense that it wouldn't be included in the config anyway (and I can see from logs that we were pulling in and then discarding a lot of old world cup articles, prior to receiving this alarm) so it seems like a low risk change to just remove it.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
