### PR TITLE
change submodule name to avoid name collision warning from jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8618,7 +8618,7 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/pressreader": {
+		"node_modules/pressreader-lambda": {
 			"resolved": "packages/pressreader",
 			"link": true
 		},
@@ -10178,6 +10178,7 @@
 			}
 		},
 		"packages/pressreader": {
+			"name": "pressreader-lambda",
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -16698,7 +16699,7 @@
 			"dev": true,
 			"peer": true
 		},
-		"pressreader": {
+		"pressreader-lambda": {
 			"version": "file:packages/pressreader",
 			"requires": {
 				"@aws-sdk/client-cloudwatch": "3.629.0",

--- a/packages/pressreader/package.json
+++ b/packages/pressreader/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "pressreader",
+	"name": "pressreader-lambda",
 	"version": "1.0.0",
 	"description": "",
 	"devDependencies": {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Resolves this warning from jest:

```
jest-haste-map: Haste module naming collision: pressreader
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/packages/pressreader/package.json
    * <rootDir>/package.json
```

Likely makes no observable difference, but one less warning is one less warning
