### PR TITLE
Add more and structured data to missing collection logging

### DIFF
--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -263,6 +263,30 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         "EvaluationPeriods": 1,
         "MetricName": "CollectionLookupFailure-TEST",
         "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "pressreaderTESTemailnotificationstopic55C74525",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
         "Period": 300,
         "Statistic": "Average",
         "Tags": [

--- a/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/pressreader.test.ts.snap
@@ -882,7 +882,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         },
         "Handler": "handler.main",
         "LoggingConfig": {
-          "LogFormat": "JSON",
+          "LogFormat": "Text",
         },
         "MemorySize": 512,
         "Role": {
@@ -1350,7 +1350,7 @@ exports[`The PressReader stack matches the snapshot 1`] = `
         },
         "Handler": "handler.main",
         "LoggingConfig": {
-          "LogFormat": "JSON",
+          "LogFormat": "Text",
         },
         "MemorySize": 512,
         "Role": {

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -182,6 +182,7 @@ export class PressReader extends GuStack {
 				evaluationPeriods: 1,
 				datapointsToAlarm: 1,
 				snsTopicName: notificationsSnsTopic.topicName,
+				okAction: true,
 			});
 		}
 

--- a/packages/cdk/lib/pressreader.ts
+++ b/packages/cdk/lib/pressreader.ts
@@ -17,7 +17,7 @@ import {
 	Role,
 	ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -243,6 +243,7 @@ export class PressReader extends GuStack {
 						lengthOfEvaluationPeriod: Duration.minutes(15),
 						numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 3,
 					},
+					loggingFormat: LoggingFormat.TEXT,
 					rules: [{ schedule: config.schedule }],
 					timeout: Duration.seconds(300),
 				},

--- a/packages/pressreader/src/processEdition.ts
+++ b/packages/pressreader/src/processEdition.ts
@@ -256,7 +256,12 @@ export function processFrontData(
 			const maybeCollection = front.data.collections.find((collection, index) =>
 				matchCollection(collection, index, identifiers),
 			);
-			decideAlerts(maybeCollection, identifiers, collectionMismatchAlarm);
+			decideAlerts(
+				maybeCollection,
+				identifiers,
+				collectionMismatchAlarm,
+				front.sectionContentURL,
+			);
 			return maybeCollection;
 		})
 		.filter(isNotUndefined);
@@ -286,10 +291,19 @@ function decideAlerts(
 	maybeCollection: CollectionType | undefined,
 	identifiers: CollectionIdentifiers,
 	collectionMismatchAlarm: () => void,
+	front: string,
 ) {
 	if (identifiers.lookupType === 'id') {
 		if (maybeCollection === undefined) {
-			console.error(`Collection not found: ${identifiers.id}`);
+			console.error(
+				JSON.stringify({
+					expectedCollectionName: identifiers.name,
+					collectionId: identifiers.id,
+					front,
+					eventType: 'CollectionNotFound',
+					message: `Collection not found: ${identifiers.id} (${identifiers.name}) at ${front}`,
+				}),
+			);
 			collectionMismatchAlarm();
 		} else if (
 			maybeCollection.displayName.trim().toLowerCase() !==


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add more and structured data to missing collection logging
- Also adjust the logFormat for the lambdas to Text, as this is what's required for our log ingestion pipeline to be able to handle (stringified) JSON as structured fields.
- Add ok action to collections alarm

The extra logging and the ok action should make it quicker to diagnose what's going on when we see a missing collection alarm, both helping us to see when the issue is just transitory, and also making it easier to identify which collection has gone missing.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, check that the logs show up as expected.

<img width="1503" alt="new fields populated in ELK" src="https://github.com/user-attachments/assets/71943b82-8030-4a3a-8668-e9b487e653e6" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
