### PR TITLE
Update AUS Headlines collection id, temporarily swap out News Extra for Federal election

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -11,7 +11,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: 'a22fa7fc-684f-484a-90bf-3f5aa4b711f7',
+							id: '"945e9c01-2834-4775-9684-991bf0c3b00d"',
 							lookupType: 'id',
 							name: 'Headlines',
 						},

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -11,7 +11,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '"945e9c01-2834-4775-9684-991bf0c3b00d"',
+							id: '945e9c01-2834-4775-9684-991bf0c3b00d',
 							lookupType: 'id',
 							name: 'Headlines',
 						},

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -53,11 +53,14 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Across the country',
 						},
-						{
-							id: '016d967f-0303-4a47-b5e0-bf6d36ad4a52',
-							lookupType: 'id',
-							name: 'News extra',
-						},
+						/**
+						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
+						 */
+						// {
+						// 	id: '016d967f-0303-4a47-b5e0-bf6d36ad4a52',
+						// 	lookupType: 'id',
+						// 	name: 'News extra',
+						// },
 						{
 							id: '0409d5d4-b375-4f3b-9ca0-d0b8f7c4ebb0',
 							lookupType: 'id',
@@ -82,6 +85,14 @@ export const ausConfig: PressReaderEditionConfig = {
 							id: '47eb1794-2f5a-490d-a3af-425d88e2d2f2',
 							lookupType: 'id',
 							name: 'Australian politics',
+						},
+						/**
+						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
+						 */
+						{
+							id: '5590a14d-5f51-4e14-ab5a-68baaff46681',
+							lookupType: 'id',
+							name: 'Federal election',
 						},
 					],
 				},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* A new collection is being used for the `Headlines` container, so update its id.
* `News Extra` has been replaced by `Federal election` until the federal election (in a month), so temporarily swap them in the config.

I've run these changes past Dave E. in Aus.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE and run lambda; check output is as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
