### PR TITLE
Update configs for new fronts

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -105,14 +105,14 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/international/lite.json',
 					collectionIds: [
 						{
-							id: '10f21d96-18f6-426f-821b-19df55dfb831',
+							id: 'a8a0658c-7c83-4a54-b371-199f54d5412e',
 							lookupType: 'id',
-							name: 'Headlines',
+							name: 'News',
 						},
 						{
-							id: '2c19b8b3-6503-4a3b-8821-9a04898b5243',
+							id: 'bd633db8-947f-4ae7-963a-a4b512883d1b',
 							lookupType: 'id',
-							name: 'Around the world',
+							name: 'World news',
 						},
 					],
 				},

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -11,9 +11,9 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '945e9c01-2834-4775-9684-991bf0c3b00d',
+							id: '7ff637c4-f97e-4c11-b6e2-4194cd918ecc',
 							lookupType: 'id',
-							name: 'Headlines',
+							name: 'News',
 						},
 						{
 							lookupType: 'index',
@@ -49,9 +49,9 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '5d60fb3d-9bb2-439b-81d4-3bd4d625165a',
+							id: 'd1626c1f-9fe1-4a47-8d04-268971292a06',
 							lookupType: 'id',
-							name: 'Across the country',
+							name: 'Australia News',
 						},
 						/**
 						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
@@ -61,11 +61,6 @@ export const ausConfig: PressReaderEditionConfig = {
 						// 	lookupType: 'id',
 						// 	name: 'News extra',
 						// },
-						{
-							id: '0409d5d4-b375-4f3b-9ca0-d0b8f7c4ebb0',
-							lookupType: 'id',
-							name: 'The rural network',
-						},
 					],
 				},
 			],
@@ -126,9 +121,9 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: 'a63f-82a9-8f63-edf1',
+							id: '5e781b03-7742-44c9-adbd-d453d118805b',
 							lookupType: 'id',
-							name: 'Around the world',
+							name: 'World news',
 						},
 					],
 				},
@@ -212,17 +207,22 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '7f0d9448-a9af-40a4-a567-24582060d46a',
+							id: 'a70f8c91-8c26-4873-96ab-330d65c582b3',
 							lookupType: 'id',
-							name: 'Spotlight',
+							name: 'Features',
 						},
 						{
-							id: 'au-alpha/features/feature-stories',
+							id: '28e8b40b-037d-41b0-ada6-7d850d7811e0',
 							lookupType: 'id',
-							name: 'Explore',
+							name: 'You may have missed',
 						},
 						{
-							id: '13636104-51ce-4264-bb6b-556c80227331',
+							id: 'e845f5d0-99eb-4608-9fcc-5891ec68dc0c',
+							lookupType: 'id',
+							name: 'More features',
+						},
+						{
+							id: '8f031865-33dc-4c62-8b2f-c9048bc201f2',
 							lookupType: 'id',
 							name: 'Lifestyle',
 						},
@@ -255,9 +255,14 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '22262088-4bce-4290-9810-cb50bbead8db',
+							id: '6e451495-7944-4850-8a3a-e1d0cd50db16',
 							lookupType: 'id',
 							name: 'Culture',
+						},
+						{
+							id: 'fed6c7be-fa5f-43ac-b61b-93fbd6fc3e6f',
+							lookupType: 'id',
+							name: 'More culture',
 						},
 					],
 				},
@@ -341,7 +346,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: 'au-alpha/contributors/feature-stories',
+							id: '7726e83-488f-4912-aacf-e9525485776b',
 							lookupType: 'id',
 							name: 'Opinion',
 						},
@@ -540,7 +545,16 @@ export const ausConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
-						{ id: 'c45d-318f-896c-3a85', lookupType: 'id', name: 'Sport' },
+						{
+							id: '84c9dd19-ecbd-4dde-b4e1-265a55f3c41b',
+							lookupType: 'id',
+							name: 'Sport',
+						},
+						{
+							id: 'f8bec169-26f1-4989-9409-52352935900b',
+							lookupType: 'id',
+							name: 'More sport',
+						},
 					],
 				},
 				{

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -754,7 +754,11 @@ export const usConfig: PressReaderEditionConfig = {
 					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/football/lite.json',
 					collectionIds: [
-						{ id: '1a78-862a-834b-b1d3', lookupType: 'id', name: 'Football' },
+						{
+							id: '4a81377e-5432-45f3-96b3-511be220e0b2',
+							lookupType: 'id',
+							name: 'Headlines',
+						},
 					],
 				},
 			],

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -11,9 +11,9 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: 'c5cad9ee-584d-4e85-85cd-bf8ee481b026',
+							id: '52a630d9-751f-4db2-810e-f6753a6d8103',
 							lookupType: 'id',
-							name: 'Headlines',
+							name: 'News',
 						},
 						{
 							lookupType: 'index',
@@ -38,12 +38,12 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: '5a59a4e5-074e-4a2a-8bbe-2743e07ae30f',
+							id: '76484132-39af-4bab-895a-8a91b6278314',
 							lookupType: 'id',
-							name: 'Across the country',
+							name: 'More US News',
 						},
 						{
-							id: '91a73cf9-8a26-4d6c-b8de-41f868e2f028',
+							id: '2d0b7e15-e596-4ca3-8d0d-aa034e6350cf',
 							lookupType: 'id',
 							name: 'In focus',
 						},
@@ -117,9 +117,9 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: '2e2035e0-7da9-4172-b0b4-787f3e2a4549',
+							id: '74570135-eb65-4662-8d43-e8ffc565a738',
 							lookupType: 'id',
-							name: 'Around the world',
+							name: 'World news',
 						},
 					],
 				},
@@ -181,14 +181,24 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: '98df412d-b0e7-4d9a-98c2-062642823e94',
+							id: '4589bc01-6a20-4b96-a313-47acdc9fc944',
 							lookupType: 'id',
 							name: 'Opinion',
 						},
 						{
-							id: 'us-alpha/features/feature-stories',
+							id: '6878462b-0c9f-4231-b7e2-17a5784c83f4',
 							lookupType: 'id',
-							name: 'Spotlight',
+							name: 'More opinion',
+						},
+						{
+							id: 'c684dad2-3853-4dc0-aa0e-57753f72fa22',
+							lookupType: 'id',
+							name: 'Features',
+						},
+						{
+							id: 'e73f0725-3b4b-4eca-83b2-9b1454a1d272',
+							lookupType: 'id',
+							name: 'More features',
 						},
 					],
 				},
@@ -219,14 +229,19 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: '5fd45b04-c512-4a8c-a9b5-cc07a6097049',
+							id: 'cca60ba5-cb25-4317-b6c8-7c75774ee276',
 							lookupType: 'id',
-							name: 'In case you missed it',
+							name: 'You may have missed',
 						},
 						{
-							id: 'us-alpha/features/feature-stories',
+							id: 'c684dad2-3853-4dc0-aa0e-57753f72fa22',
 							lookupType: 'id',
-							name: 'Spotlight',
+							name: 'Features',
+						},
+						{
+							id: 'e73f0725-3b4b-4eca-83b2-9b1454a1d272',
+							lookupType: 'id',
+							name: 'More features',
 						},
 					],
 				},
@@ -235,9 +250,14 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
 					collectionIds: [
 						{
-							id: '98df412d-b0e7-4d9a-98c2-062642823e94',
+							id: '4589bc01-6a20-4b96-a313-47acdc9fc944',
 							lookupType: 'id',
 							name: 'Opinion',
+						},
+						{
+							id: '6878462b-0c9f-4231-b7e2-17a5784c83f4',
+							lookupType: 'id',
+							name: 'More opinion',
 						},
 					],
 				},
@@ -263,14 +283,19 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: 'us-alpha/features/feature-stories',
+							id: 'c684dad2-3853-4dc0-aa0e-57753f72fa22',
 							lookupType: 'id',
-							name: 'Spotlight',
+							name: 'Features',
 						},
 						{
-							id: '5fd45b04-c512-4a8c-a9b5-cc07a6097049',
+							id: 'e73f0725-3b4b-4eca-83b2-9b1454a1d272',
 							lookupType: 'id',
-							name: 'In case you missed it',
+							name: 'More features',
+						},
+						{
+							id: 'cca60ba5-cb25-4317-b6c8-7c75774ee276',
+							lookupType: 'id',
+							name: 'You may have missed',
 						},
 					],
 				},
@@ -371,9 +396,14 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: 'fb59c1f8-72a7-41d5-8365-a4d574809bed',
+							id: '10fc72da-b0ed-4509-bf6a-d5e64f7cff02',
 							lookupType: 'id',
 							name: 'Culture',
+						},
+						{
+							id: 'fed6c7be-fa5f-43ac-b61b-93fbd6fc3e6f',
+							lookupType: 'id',
+							name: 'More culture',
 						},
 					],
 				},
@@ -524,9 +554,9 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
-							id: '972a5c22-6650-4a36-9f34-f4864dae0bf5',
+							id: '54223e8e-fcf4-4a14-b814-ec6726a25a3e',
 							lookupType: 'id',
-							name: 'Climate crisis',
+							name: 'Climate crisis & environment',
 						},
 					],
 				},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates a number of containers on the US and AU network fronts, in response to a number of collections being swapped out on these fronts.

This has been checked with JW in Licensing.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
