### PR TITLE
Fix AUS collection ids

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -53,14 +53,11 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Australia News',
 						},
-						/**
-						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
-						 */
-						// {
-						// 	id: '016d967f-0303-4a47-b5e0-bf6d36ad4a52',
-						// 	lookupType: 'id',
-						// 	name: 'News extra',
-						// },
+						{
+							id: 'ef2e69b5-9c2f-4cd9-8c7a-4d374028acba',
+							lookupType: 'id',
+							name: 'More news',
+						},
 					],
 				},
 			],
@@ -81,6 +78,12 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Australian politics',
 						},
+					],
+				},
+				{
+					sectionContentURL:
+						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
+					collectionIds: [
 						/**
 						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
 						 */

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -85,7 +85,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
 						 */
 						{
-							id: '5590a14d-5f51-4e14-ab5a-68baaff46681',
+							id: '18f49716-47e2-4296-861e-64ccdf6d6150',
 							lookupType: 'id',
 							name: 'Federal election',
 						},
@@ -346,7 +346,7 @@ export const ausConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
 					collectionIds: [
 						{
-							id: '7726e83-488f-4912-aacf-e9525485776b',
+							id: 'd7726e83-488f-4912-aacf-e9525485776b',
 							lookupType: 'id',
 							name: 'Opinion',
 						},

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -757,7 +757,7 @@ export const usConfig: PressReaderEditionConfig = {
 						{
 							id: '4a81377e-5432-45f3-96b3-511be220e0b2',
 							lookupType: 'id',
-							name: 'Headlines',
+							name: 'Football',
 						},
 					],
 				},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- One probable typo (Opinion)
- One that I think was replaced a little while ago but I missed it (Federal election)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
