### PR TITLE
Fix US config

### DIFF
--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -488,11 +488,6 @@ export const ausConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Key issues',
 						},
-						{
-							id: '75fd1561-aad3-4e69-baf8-278f7db65050',
-							lookupType: 'id',
-							name: 'Coronavirus',
-						},
 					],
 				},
 			],

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -619,11 +619,6 @@ export const usConfig: PressReaderEditionConfig = {
 							name: 'News',
 						},
 						{
-							id: '75fd1561-aad3-4e69-baf8-278f7db65050',
-							lookupType: 'id',
-							name: 'Coronavirus',
-						},
-						{
 							id: '29b0-f2f0-0c41-3cee',
 							lookupType: 'id',
 							name: 'Opinion',

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -706,17 +706,6 @@ export const usConfig: PressReaderEditionConfig = {
 			frontSources: [
 				{
 					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
-					collectionIds: [
-						{
-							id: 'afd83b7b-647f-47a6-a0c1-a875a7dea2c9',
-							lookupType: 'id',
-							name: 'US sports',
-						},
-					],
-				},
-				{
-					sectionContentURL:
 						'https://api.nextgen.guardianapps.co.uk/us/sport/lite.json',
 					collectionIds: [
 						{

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -247,7 +247,7 @@ export const usConfig: PressReaderEditionConfig = {
 				},
 				{
 					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
+						'https://api.nextgen.guardianapps.co.uk/us/lite.json',
 					collectionIds: [
 						{
 							id: '4589bc01-6a20-4b96-a313-47acdc9fc944',
@@ -401,7 +401,7 @@ export const usConfig: PressReaderEditionConfig = {
 							name: 'Culture',
 						},
 						{
-							id: 'fed6c7be-fa5f-43ac-b61b-93fbd6fc3e6f',
+							id: '0c3c398f-e49a-4569-a8bd-1ef289fb9319',
 							lookupType: 'id',
 							name: 'More culture',
 						},
@@ -709,7 +709,7 @@ export const usConfig: PressReaderEditionConfig = {
 						'https://api.nextgen.guardianapps.co.uk/us-news/lite.json',
 					collectionIds: [
 						{
-							id: 'c8132ecb-e937-4032-b69d-908f09c838a0',
+							id: 'afd83b7b-647f-47a6-a0c1-a875a7dea2c9',
 							lookupType: 'id',
 							name: 'US sports',
 						},
@@ -724,7 +724,11 @@ export const usConfig: PressReaderEditionConfig = {
 							lookupType: 'id',
 							name: 'Across the country',
 						},
-						{ id: 'f6dd-d7b1-0e85-4650', lookupType: 'id', name: 'Sports' },
+						{
+							id: 'afd83b7b-647f-47a6-a0c1-a875a7dea2c9',
+							lookupType: 'id',
+							name: 'Sports',
+						},
 					],
 				},
 				{

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -757,7 +757,7 @@ export const usConfig: PressReaderEditionConfig = {
 						{
 							id: '4a81377e-5432-45f3-96b3-511be220e0b2',
 							lookupType: 'id',
-							name: 'Headlines',
+							name: 'Football',
 						},
 					],
 				},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
