### PR TITLE
Update US Technology collections

### DIFF
--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -651,14 +651,9 @@ export const usConfig: PressReaderEditionConfig = {
 							name: 'In depth',
 						},
 						{
-							id: '1312e7d1-57b5-49e3-900e-795f03620157',
+							id: '6bb3-9f76-43bd-4213',
 							lookupType: 'id',
-							name: 'News',
-						},
-						{
-							id: 'a014f653-dee0-4d72-84f9-7b5e7df1fc83',
-							lookupType: 'id',
-							name: 'Privacy',
+							name: 'Technology',
 						},
 						{
 							id: 'cff4aa48-dd86-433f-bc11-eb15abae55fc',
@@ -684,11 +679,6 @@ export const usConfig: PressReaderEditionConfig = {
 							id: 'c66d-aa1a-e12d-fc7a',
 							lookupType: 'id',
 							name: 'Reviews',
-						},
-						{
-							id: '00e17f51-a01d-4df0-9363-4a383f5922b2',
-							lookupType: 'id',
-							name: 'Devices',
 						},
 					],
 				},

--- a/packages/pressreader/src/editionConfigs/usConfig.ts
+++ b/packages/pressreader/src/editionConfigs/usConfig.ts
@@ -666,7 +666,7 @@ export const usConfig: PressReaderEditionConfig = {
 							name: 'Opinion & analysis',
 						},
 						{
-							id: '16069bf1-3d0e-4c7a-abb2-b77f9ce7e071',
+							id: '75bec33c-9117-4fe5-80ad-f242818cf3fa',
 							lookupType: 'id',
 							name: 'Games',
 						},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Privacy and Devices have been removed
- News has been replaced by a new Technology collection
- Games has a new collection id

Changes checked with JW from licensing and tested in CODE 👍 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
