### PR TITLE
Australian config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.tsbuildinfo
 .tmp
 scripts/dev-untracked
+.vscode

--- a/packages/pressreader/src/editionConfigs/ausConfig.ts
+++ b/packages/pressreader/src/editionConfigs/ausConfig.ts
@@ -80,20 +80,6 @@ export const ausConfig: PressReaderEditionConfig = {
 						},
 					],
 				},
-				{
-					sectionContentURL:
-						'https://api.nextgen.guardianapps.co.uk/au/lite.json',
-					collectionIds: [
-						/**
-						 * Federal election replaces 'News Extra' for the next few weeks (election is 2025-05-03)
-						 */
-						{
-							id: '18f49716-47e2-4296-861e-64ccdf6d6150',
-							lookupType: 'id',
-							name: 'Federal election',
-						},
-					],
-				},
 			],
 			capiSources: [
 				'search?tag=australia-news%2Faustralian-politics&order-by=newest',
@@ -289,7 +275,7 @@ export const ausConfig: PressReaderEditionConfig = {
 							name: 'Australia this month',
 						},
 						{
-							id: 'b375bd53-c074-421d-89c4-8bda68a186b6',
+							id: '5a2f4701-213e-4feb-8818-acc93cdb472d',
 							lookupType: 'id',
 							name: 'Australian reviews',
 						},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Update collection id for 'Australian reviews'
- Remove temporary 'Federal election' collection
- Update .gitignore

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
